### PR TITLE
test: budget the bundle container build tests for coverage instrumentation

### DIFF
--- a/tests/unit/Core/Checkout/CheckoutTest.php
+++ b/tests/unit/Core/Checkout/CheckoutTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout;
 
+use Ergebnis\PHPUnit\SlowTestDetector\Attribute\MaximumDuration;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Checkout;
@@ -17,6 +18,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 #[CoversClass(Checkout::class)]
 class CheckoutTest extends TestCase
 {
+    // building the full bundle container is legitimately slower under coverage instrumentation,
+    // and whichever build test runs first also pays the one-time symfony-dependency-injection load
+    #[MaximumDuration(2000)]
     public function testBuildUsesRedisCompilerPass(): void
     {
         $container = new ContainerBuilder();

--- a/tests/unit/Core/Content/ContentTest.php
+++ b/tests/unit/Core/Content/ContentTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Content;
 
+use Ergebnis\PHPUnit\SlowTestDetector\Attribute\MaximumDuration;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Content;
@@ -16,6 +17,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 #[CoversClass(Content::class)]
 class ContentTest extends TestCase
 {
+    // building the full bundle container is legitimately slower under coverage instrumentation,
+    // and whichever build test runs first also pays the one-time symfony-dependency-injection load
+    #[MaximumDuration(2000)]
     public function testBuild(): void
     {
         $content = new Content();

--- a/tests/unit/Core/Framework/FrameworkTest.php
+++ b/tests/unit/Core/Framework/FrameworkTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Framework;
 
+use Ergebnis\PHPUnit\SlowTestDetector\Attribute\MaximumDuration;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Cache\CacheClearer;
@@ -38,6 +39,9 @@ class FrameworkTest extends TestCase
         static::assertSame(-1, $framework->getTemplatePriority());
     }
 
+    // building the full bundle container is legitimately slower under coverage instrumentation,
+    // and whichever build test runs first also pays the one-time symfony-dependency-injection load
+    #[MaximumDuration(2000)]
     public function testBuild(): void
     {
         $container = $this->buildContainer('prod');
@@ -55,6 +59,7 @@ class FrameworkTest extends TestCase
         static::assertEmpty(array_filter($passes, static fn ($pass) => $pass instanceof DisableRateLimiterCompilerPass));
     }
 
+    #[MaximumDuration(2000)]
     public function testBuildRegistersTestServicesInTestEnvironment(): void
     {
         $container = $this->buildContainer('test');


### PR DESCRIPTION
### 1. Why is this change necessary?

The bundle container build tests keep appearing in the slow-test report of the coverage CI job (`FrameworkTest::testBuildRegistersTestServicesInTestEnvironment` topped it at 1.4s) although they run in well under 50ms without instrumentation. Building a bundle container executes dozens of service definition files, which is expensive to line-instrument, and whichever build test runs first in the randomized order also pays the one-time symfony-dependency-injection load. The reports drown real regressions in known noise.

### 2. What does this change do, exactly?

Gives the four bundle container build tests (`FrameworkTest::testBuild`, `FrameworkTest::testBuildRegistersTestServicesInTestEnvironment`, `ContentTest::testBuild`, `CheckoutTest::testBuildUsesRedisCompilerPass`) an explicit `#[MaximumDuration(2000)]` from the slow-test detector, the first use of the per-test budget in this repository. The detector keeps watching them against that budget; they only leave the report as long as they stay under it.

### 3. Describe each step to reproduce the issue or behaviour.

The `PHPUnit for unit` job on any recent PR lists these tests in the "duration exceeded the global maximum duration (0.500)" table, for example run 30407522956. Locally, `docker compose exec web vendor/bin/phpunit tests/unit/Core/Framework/FrameworkTest.php` finishes the whole class in about 0.14s.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change (not applicable: attribute-only change to existing tests)
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
