### PR TITLE
test(framework): assert the runtime configuration applied on boot

### DIFF
--- a/tests/unit/Core/Framework/FrameworkTest.php
+++ b/tests/unit/Core/Framework/FrameworkTest.php
@@ -3,13 +3,17 @@
 namespace Shopware\Tests\Unit\Core\Framework;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Cache\CacheClearer;
+use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\Adapter\Cache\StampedeProtectionConfigurator;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DependencyInjection\CompilerPass\EntityCompilerPass;
 use Shopware\Core\Framework\DependencyInjection\CompilerPass\FeatureFlagCompilerPass;
 use Shopware\Core\Framework\DependencyInjection\CompilerPass\McpToolDiscoveryCompilerPass;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Feature\FeatureFlagRegistry;
 use Shopware\Core\Framework\Framework;
 use Shopware\Core\Framework\Log\Package;
@@ -66,7 +70,9 @@ class FrameworkTest extends TestCase
         static::assertNotEmpty(array_filter($passes, static fn ($pass) => $pass instanceof ContainerVisibilityCompilerPass));
     }
 
-    public function testFeatureFlagRegisteredOnBoot(): void
+    #[TestDox('boot registers the feature flags and applies the runtime configuration')]
+    #[DataProvider('bootConfigurationProvider')]
+    public function testBootAppliesRuntimeConfiguration(bool $compress, string $compressMethod, bool $debug): void
     {
         $container = new Container();
         $registry = $this->createMock(FeatureFlagRegistry::class);
@@ -80,16 +86,33 @@ class FrameworkTest extends TestCase
         $container->set(DefinitionInstanceRegistry::class, static::createStub(DefinitionInstanceRegistry::class));
         $container->set(SalesChannelDefinitionInstanceRegistry::class, static::createStub(SalesChannelDefinitionInstanceRegistry::class));
         $container->setParameter('kernel.cache_dir', '/tmp');
-        $container->setParameter('shopware.cache.compress', true);
-        $container->setParameter('shopware.cache.compression_method', 'gzip');
-        $container->setParameter('kernel.debug', true);
+        $container->setParameter('shopware.cache.compress', $compress);
+        $container->setParameter('shopware.cache.compression_method', $compressMethod);
+        $container->setParameter('kernel.debug', $debug);
         $container->setParameter('kernel.environment', 'test');
         $container->compile();
 
         $framework = new Framework();
         $framework->setContainer($container);
 
-        $framework->boot();
+        // boot() assigns process-global statics: restore them so no other test inherits this run
+        $before = [CacheValueCompressor::$compress, CacheValueCompressor::$compressMethod, Feature::$emitDeprecations];
+
+        try {
+            $framework->boot();
+
+            static::assertSame($compress, CacheValueCompressor::$compress);
+            static::assertSame($compressMethod, CacheValueCompressor::$compressMethod);
+            static::assertSame($debug, Feature::$emitDeprecations);
+        } finally {
+            [CacheValueCompressor::$compress, CacheValueCompressor::$compressMethod, Feature::$emitDeprecations] = $before;
+        }
+    }
+
+    public static function bootConfigurationProvider(): \Generator
+    {
+        yield 'debug with gzip compression' => [true, 'gzip', true];
+        yield 'no debug, no compression, zstd configured' => [false, 'zstd', false];
     }
 
     private function buildContainer(string $environment): ContainerBuilder


### PR DESCRIPTION
### 1. Why is this change necessary?

`FrameworkTest::testFeatureFlagRegisteredOnBoot` executed most of `Framework::boot()` without asserting it: the `CacheValueCompressor` and `Feature::$emitDeprecations` assignments could be deleted with the test staying green. It also left those process-global statics mutated (`gzip`/`true`/`true`), leaking state into every unit test running after it in the same process.

### 2. What does this change do, exactly?

- Renames the test to `testBootAppliesRuntimeConfiguration` and drives it with a two-case provider whose values straddle the statics' defaults, so removing any assignment in `boot()` fails at least one case. The feature-flag registration and stampede-protection expectations stay as before.
- Snapshots the statics before `boot()` and restores them in `finally`, removing the cross-test pollution.

### 3. Describe each step to reproduce the issue or behaviour.

Delete the `CacheValueCompressor::$compress` assignment in `Framework::boot()` on trunk: the old test stays green. With this change, `docker compose exec web vendor/bin/phpunit tests/unit/Core/Framework/FrameworkTest.php` fails the `no debug, no compression, zstd configured` case.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
