### PR TITLE
fix: retry MySQL 8.4 FK guard failures per DDL statement instead of closure wrapping

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -35,16 +35,14 @@ List options (`plugins`, `excluded_locales`, `plugin_mapping`, `languages`) repl
 
 MySQL 8.4 enables `restrict_fk_on_non_standard_key` by default. While that guard is on, MySQL bug [#118151](https://bugs.mysql.com/bug.php?id=118151) makes any `ALTER TABLE` or `CREATE INDEX` on a table fail with `Cannot drop index '<unknown key name>': needed in a foreign key constraint` when that table is involved in a foreign key with a non-standard supporting key. Shops carrying such drift from older Shopware versions or from extensions could not run product-table migrations at all.
 
-All core migrations doing DDL on the `product` table now run that DDL with the guard relaxed for the current session, restoring the previous value afterwards. On MariaDB and MySQL versions without the variable, nothing changes.
+Migration DDL now retries such failures: the statement runs unmodified first, and only when the server rejects it with that error while the guard is on is the guard relaxed for a single retry, restoring the previous value afterwards. Healthy schemas, MariaDB, and MySQL versions without the variable see no behaviour change; legitimate failures still surface, because they fail the retry as well.
 
-Extension migrations can hit the same failure. `MigrationStep::withRelaxedNonStandardFkGuard()` wraps the affected DDL:
+The `MigrationStep` DDL helpers (`addColumn()`, `dropColumnIfExists()`, `dropForeignKeyIfExists()`, `dropIndexIfExists()`, `updateInheritance()`) retry automatically, in core and extension migrations alike. For raw DDL statements, extension migrations can use `MigrationStep::executeDdlStatement()`:
 
 ```php
 public function update(Connection $connection): void
 {
-    $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-        $connection->executeStatement('ALTER TABLE `product` ADD COLUMN `my_column` VARCHAR(32) NULL');
-    });
+    $this->executeDdlStatement($connection, 'ALTER TABLE `product` ADD COLUMN `my_column` VARCHAR(32) NULL');
 }
 ```
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -33,11 +33,9 @@ List options (`plugins`, `excluded_locales`, `plugin_mapping`, `languages`) repl
 
 ### Product migrations no longer fail on MySQL 8.4 with non-standard foreign keys
 
-MySQL 8.4 enables `restrict_fk_on_non_standard_key` by default. While that guard is on, MySQL bug [#118151](https://bugs.mysql.com/bug.php?id=118151) makes any `ALTER TABLE` or `CREATE INDEX` on a table fail with `Cannot drop index '<unknown key name>': needed in a foreign key constraint` when that table is involved in a foreign key with a non-standard supporting key. Shops carrying such drift from older Shopware versions or from extensions could not run product-table migrations at all.
+On MySQL 8.4, bug [#118151](https://bugs.mysql.com/bug.php?id=118151) made `ALTER TABLE` and `CREATE INDEX` fail on tables involved in a foreign key with a non-standard supporting key, blocking product-table migrations on shops carrying such drift. Migration DDL now retries such a failure once with `restrict_fk_on_non_standard_key` relaxed, restoring it afterwards. Healthy schemas, MariaDB, and MySQL without the variable are unaffected; legitimate failures fail the retry as well.
 
-Migration DDL now retries such failures: the statement runs unmodified first, and only when the server rejects it with that error while the guard is on is the guard relaxed for a single retry, restoring the previous value afterwards. Healthy schemas, MariaDB, and MySQL versions without the variable see no behaviour change; legitimate failures still surface, because they fail the retry as well.
-
-The `MigrationStep` DDL helpers (`addColumn()`, `dropColumnIfExists()`, `dropForeignKeyIfExists()`, `dropIndexIfExists()`, `updateInheritance()`) retry automatically, in core and extension migrations alike. For raw DDL statements, extension migrations can use `MigrationStep::executeDdlStatement()`:
+The `MigrationStep` DDL helpers retry automatically, in core and extension migrations alike. For raw DDL statements, extension migrations can use `MigrationStep::executeDdlStatement()`:
 
 ```php
 public function update(Connection $connection): void

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Migration/NonStandardFkGuardRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Migration/NonStandardFkGuardRule.php
@@ -14,14 +14,9 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * Requires raw DDL against {@see self::TABLES_WITH_KNOWN_DRIFT} to go through
  * {@see \Shopware\Core\Framework\Migration\MigrationStep::executeDdlStatement()}, which retries
- * with the FK guard relaxed when MySQL 8.4 rejects the statement (bug #118151). The MigrationStep
- * DDL helpers (addColumn, dropColumnIfExists, dropForeignKeyIfExists, dropIndexIfExists,
- * updateInheritance) already run through it and need no attention.
- *
- * Whether a shop is affected depends on its schema history, which static analysis cannot see, so
- * the rule guards the tables where drift has been reported rather than a derived category.
- *
- * The MySQL 8.4 regression test in the devops suite covers the behaviour itself.
+ * when MySQL 8.4 rejects the statement (bug #118151). The MigrationStep DDL helpers retry
+ * themselves. Which shops are affected depends on schema history, so the rule guards the tables
+ * with reported drift; the MySQL 8.4 devops test covers the behaviour itself.
  *
  * @internal
  *

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Migration/NonStandardFkGuardRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Migration/NonStandardFkGuardRule.php
@@ -12,15 +12,16 @@ use PHPStan\Rules\RuleErrorBuilder;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * Requires DDL against {@see self::TABLES_WITH_KNOWN_DRIFT} to run inside
- * {@see \Shopware\Core\Framework\Migration\MigrationStep::withRelaxedNonStandardFkGuard()},
- * otherwise it fails on MySQL 8.4 (bug #118151).
+ * Requires raw DDL against {@see self::TABLES_WITH_KNOWN_DRIFT} to go through
+ * {@see \Shopware\Core\Framework\Migration\MigrationStep::executeDdlStatement()}, which retries
+ * with the FK guard relaxed when MySQL 8.4 rejects the statement (bug #118151). The MigrationStep
+ * DDL helpers (addColumn, dropColumnIfExists, dropForeignKeyIfExists, dropIndexIfExists,
+ * updateInheritance) already run through it and need no attention.
  *
  * Whether a shop is affected depends on its schema history, which static analysis cannot see, so
  * the rule guards the tables where drift has been reported rather than a derived category.
  *
- * The wrapping check is coarse: it only asserts the statement sits inside some closure. The
- * MySQL 8.4 regression test in the devops suite covers the behaviour itself.
+ * The MySQL 8.4 regression test in the devops suite covers the behaviour itself.
  *
  * @internal
  *
@@ -43,17 +44,6 @@ class NonStandardFkGuardRule implements Rule
         'product',
     ];
 
-    /**
-     * MigrationStep helpers that issue ALTER TABLE, with the position of their table argument.
-     */
-    private const TABLE_ARGUMENT_METHODS = [
-        'addColumn' => 1,
-        'dropColumnIfExists' => 1,
-        'dropForeignKeyIfExists' => 1,
-        'dropIndexIfExists' => 1,
-        'updateInheritance' => 1,
-    ];
-
     public function getNodeType(): string
     {
         return MethodCall::class;
@@ -65,23 +55,27 @@ class NonStandardFkGuardRule implements Rule
             return [];
         }
 
+        if ($node->name->toString() !== 'executeStatement') {
+            return [];
+        }
+
         if (!$this->isInMigrationClass($scope) || !$this->isRecentMigration($scope)) {
             return [];
         }
 
-        $table = $this->getTargetedDriftedTable($node);
-        if ($table === null) {
+        $sql = $node->getArgs()[0]->value ?? null;
+        if (!$sql instanceof String_) {
             return [];
         }
 
-        // Anything inside a closure is assumed to be wrapped by the guard helper.
-        if ($scope->isInAnonymousFunction()) {
+        $table = $this->getDriftedTableFromSql($sql->value);
+        if ($table === null) {
             return [];
         }
 
         return [
             RuleErrorBuilder::message(\sprintf(
-                'DDL against "%s" must run inside MigrationStep::withRelaxedNonStandardFkGuard(), otherwise it '
+                'Raw DDL against "%s" must go through MigrationStep::executeDdlStatement(), otherwise it '
                 . 'fails on MySQL 8.4 for the shops that carry non-standard foreign key drift against that '
                 . 'table (MySQL bug #118151).',
                 $table
@@ -101,34 +95,6 @@ class NonStandardFkGuardRule implements Rule
         }
 
         return (int) $matches[1] > (int) strtotime(self::CUTOFF_UNIX_TIMESTAMP);
-    }
-
-    private function getTargetedDriftedTable(MethodCall $node): ?string
-    {
-        $method = $node->name;
-        if (!$method instanceof Identifier) {
-            return null;
-        }
-
-        $args = $node->getArgs();
-
-        $tableArgumentPosition = self::TABLE_ARGUMENT_METHODS[$method->toString()] ?? null;
-        if ($tableArgumentPosition !== null) {
-            $table = $args[$tableArgumentPosition]->value ?? null;
-
-            return $table instanceof String_ && $this->hasKnownDrift($table->value) ? $table->value : null;
-        }
-
-        if ($args === []) {
-            return null;
-        }
-
-        $sql = $args[0]->value;
-        if (!$sql instanceof String_) {
-            return null;
-        }
-
-        return $this->getDriftedTableFromSql($sql->value);
     }
 
     private function getDriftedTableFromSql(string $sql): ?string

--- a/src/Core/Framework/Migration/AddColumnTrait.php
+++ b/src/Core/Framework/Migration/AddColumnTrait.php
@@ -39,11 +39,11 @@ trait AddColumnTrait
 
         try {
             // Try INSTANT first – fast metadata-only operation, no table rebuild.
-            $connection->executeStatement($sql . ', ALGORITHM=INSTANT;');
+            NonStandardFkGuard::executeDdl($connection, $sql . ', ALGORITHM=INSTANT;');
         } catch (DBALException) {
             // INSTANT not supported for this operation (e.g., expression defaults, fulltext tables).
             // Fall back to regular ALTER TABLE and let MySQL pick the best algorithm.
-            $connection->executeStatement($sql . ';');
+            NonStandardFkGuard::executeDdl($connection, $sql . ';');
         }
 
         return true;

--- a/src/Core/Framework/Migration/InheritanceUpdaterTrait.php
+++ b/src/Core/Framework/Migration/InheritanceUpdaterTrait.php
@@ -16,6 +16,6 @@ trait InheritanceUpdaterTrait
             'ALTER TABLE `#table#` ADD COLUMN `#column#` binary(16) NULL'
         );
 
-        $connection->executeStatement($sql);
+        NonStandardFkGuard::executeDdl($connection, $sql);
     }
 }

--- a/src/Core/Framework/Migration/MigrationStep.php
+++ b/src/Core/Framework/Migration/MigrationStep.php
@@ -101,11 +101,9 @@ abstract class MigrationStep
     }
 
     /**
-     * Executes a DDL statement, retrying with `restrict_fk_on_non_standard_key` relaxed when
-     * MySQL 8.4 rejects it because of bug #118151 (non-standard foreign key drift against the
-     * table). Use it for raw `ALTER TABLE` / `CREATE INDEX` statements in migrations; the
-     * `addColumn()`, `dropColumnIfExists()`, `dropForeignKeyIfExists()`, `dropIndexIfExists()`
-     * and `updateInheritance()` helpers already run through it.
+     * Executes a raw DDL statement, retrying with the FK guard relaxed when MySQL 8.4 rejects it
+     * through bug #118151. The addColumn() / drop*IfExists() / updateInheritance() helpers
+     * already run through it.
      *
      * @see NonStandardFkGuard
      *

--- a/src/Core/Framework/Migration/MigrationStep.php
+++ b/src/Core/Framework/Migration/MigrationStep.php
@@ -22,8 +22,6 @@ abstract class MigrationStep
 
     private const MAX_INT_32_BIT = 2147483647;
 
-    private const NON_STANDARD_FK_GUARD = 'restrict_fk_on_non_standard_key';
-
     /**
      * get creation timestamp
      */
@@ -103,45 +101,20 @@ abstract class MigrationStep
     }
 
     /**
-     * Runs DDL with `restrict_fk_on_non_standard_key` relaxed for the current session.
+     * Executes a DDL statement, retrying with `restrict_fk_on_non_standard_key` relaxed when
+     * MySQL 8.4 rejects it because of bug #118151 (non-standard foreign key drift against the
+     * table). Use it for raw `ALTER TABLE` / `CREATE INDEX` statements in migrations; the
+     * `addColumn()`, `dropColumnIfExists()`, `dropForeignKeyIfExists()`, `dropIndexIfExists()`
+     * and `updateInheritance()` helpers already run through it.
      *
-     * MySQL 8.4 enables that guard by default, and while it is on, MySQL bug #118151 makes any
-     * `ALTER TABLE` / `CREATE INDEX` on a table fail with `Cannot drop index '<unknown key name>':
-     * needed in a foreign key constraint` when the table is involved in a foreign key with a
-     * non-standard supporting key. Shops carrying such drift cannot upgrade without this.
+     * @see NonStandardFkGuard
      *
-     * On MariaDB and MySQL < 8.4 the variable does not exist and the callback just runs as-is.
-     *
-     * @see https://bugs.mysql.com/bug.php?id=118151
-     *
-     * @internal Temporary workaround, will be removed once MySQL fixes bug #118151
+     * @internal Temporary workaround, will be removed once MySQL fixes bug #118151; safe to call
+     *           from extension migrations in the meantime.
      */
-    protected function withRelaxedNonStandardFkGuard(Connection $connection, \Closure $ddl): void
+    protected function executeDdlStatement(Connection $connection, string $sql): void
     {
-        // Empty result means the server does not know the variable. More reliable than parsing
-        // VERSION(), which reports strings like "5.5.5-10.11.2-MariaDB" that compare as >= 8.4.
-        $guard = $connection->fetchAssociative(
-            'SHOW SESSION VARIABLES LIKE :variable',
-            ['variable' => self::NON_STANDARD_FK_GUARD]
-        );
-
-        if ($guard === false) {
-            $ddl();
-
-            return;
-        }
-
-        $connection->executeStatement('SET SESSION ' . self::NON_STANDARD_FK_GUARD . ' = OFF');
-
-        try {
-            $ddl();
-        } finally {
-            $connection->executeStatement(\sprintf(
-                'SET SESSION %s = %s',
-                self::NON_STANDARD_FK_GUARD,
-                $connection->quote((string) $guard['Value'])
-            ));
-        }
+        NonStandardFkGuard::executeDdl($connection, $sql);
     }
 
     protected function dropTableIfExists(Connection $connection, string $table): void
@@ -156,7 +129,7 @@ abstract class MigrationStep
     protected function dropColumnIfExists(Connection $connection, string $table, string $columnName): bool
     {
         try {
-            $connection->executeStatement(\sprintf('ALTER TABLE `%s` DROP COLUMN `%s`', $table, $columnName));
+            NonStandardFkGuard::executeDdl($connection, \sprintf('ALTER TABLE `%s` DROP COLUMN `%s`', $table, $columnName));
         } catch (\Throwable $e) {
             if ($e instanceof TableNotFoundException) {
                 return false;
@@ -181,7 +154,7 @@ abstract class MigrationStep
         $sql = \sprintf('ALTER TABLE `%s` DROP FOREIGN KEY `%s`', $table, $foreignKeyName);
 
         try {
-            $connection->executeStatement($sql);
+            NonStandardFkGuard::executeDdl($connection, $sql);
         } catch (\Throwable $e) {
             if ($e instanceof TableNotFoundException) {
                 return false;
@@ -206,7 +179,7 @@ abstract class MigrationStep
         $sql = \sprintf('ALTER TABLE `%s` DROP INDEX `%s`', $table, $indexName);
 
         try {
-            $connection->executeStatement($sql);
+            NonStandardFkGuard::executeDdl($connection, $sql);
         } catch (\Throwable $e) {
             if ($e instanceof TableNotFoundException) {
                 return false;

--- a/src/Core/Framework/Migration/NonStandardFkGuard.php
+++ b/src/Core/Framework/Migration/NonStandardFkGuard.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\DriverException;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Executes DDL statements, retrying with `restrict_fk_on_non_standard_key` relaxed when the
+ * statement trips MySQL bug #118151.
+ *
+ * MySQL 8.4 enables that guard by default, and while it is on, the bug makes any `ALTER TABLE` /
+ * `CREATE INDEX` on a table fail with `Cannot drop index '<unknown key name>': needed in a
+ * foreign key constraint` (error 1553) when the table is involved in a foreign key with a
+ * non-standard supporting key. Shops carrying such drift cannot upgrade without this.
+ *
+ * The statement always runs unmodified first. Only when it failed with error 1553 while the
+ * guard is ON is the guard relaxed for a single retry, restoring the previous value afterwards.
+ * A legitimate 1553 failure fails the retry as well and surfaces as usual, so behaviour only
+ * changes for statements the bug would otherwise reject. On MariaDB and MySQL < 8.4 the
+ * variable does not exist and no retry happens.
+ *
+ * @see https://bugs.mysql.com/bug.php?id=118151
+ *
+ * @internal Temporary workaround, will be removed once MySQL fixes bug #118151
+ */
+#[Package('framework')]
+final class NonStandardFkGuard
+{
+    private const GUARD_VARIABLE = 'restrict_fk_on_non_standard_key';
+
+    private const ER_DROP_INDEX_FK = 1553;
+
+    public static function executeDdl(Connection $connection, string $sql): void
+    {
+        try {
+            $connection->executeStatement($sql);
+        } catch (DriverException $e) {
+            if ($e->getCode() !== self::ER_DROP_INDEX_FK) {
+                throw $e;
+            }
+
+            self::retryWithRelaxedGuard($connection, $sql, $e);
+        }
+    }
+
+    private static function retryWithRelaxedGuard(Connection $connection, string $sql, DriverException $original): void
+    {
+        // Empty result means the server does not know the variable. More reliable than parsing
+        // VERSION(), which reports strings like "5.5.5-10.11.2-MariaDB" that compare as >= 8.4.
+        $guard = $connection->fetchAssociative(
+            'SHOW SESSION VARIABLES LIKE :variable',
+            ['variable' => self::GUARD_VARIABLE]
+        );
+
+        // Variable absent (MariaDB, MySQL < 8.4) or already relaxed: the guard did not cause the
+        // failure, so a retry cannot change the outcome.
+        if ($guard === false || $guard['Value'] !== 'ON') {
+            throw $original;
+        }
+
+        $connection->executeStatement('SET SESSION ' . self::GUARD_VARIABLE . ' = OFF');
+
+        try {
+            $connection->executeStatement($sql);
+        } finally {
+            $connection->executeStatement('SET SESSION ' . self::GUARD_VARIABLE . ' = ON');
+        }
+    }
+}

--- a/src/Core/Framework/Migration/NonStandardFkGuard.php
+++ b/src/Core/Framework/Migration/NonStandardFkGuard.php
@@ -7,19 +7,12 @@ use Doctrine\DBAL\Exception\DriverException;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * Executes DDL statements, retrying with `restrict_fk_on_non_standard_key` relaxed when the
- * statement trips MySQL bug #118151.
- *
- * MySQL 8.4 enables that guard by default, and while it is on, the bug makes any `ALTER TABLE` /
- * `CREATE INDEX` on a table fail with `Cannot drop index '<unknown key name>': needed in a
- * foreign key constraint` (error 1553) when the table is involved in a foreign key with a
- * non-standard supporting key. Shops carrying such drift cannot upgrade without this.
- *
- * The statement always runs unmodified first. Only when it failed with error 1553 while the
- * guard is ON is the guard relaxed for a single retry, restoring the previous value afterwards.
- * A legitimate 1553 failure fails the retry as well and surfaces as usual, so behaviour only
- * changes for statements the bug would otherwise reject. On MariaDB and MySQL < 8.4 the
- * variable does not exist and no retry happens.
+ * Executes DDL, retrying once with `restrict_fk_on_non_standard_key` relaxed when MySQL 8.4
+ * rejects the statement with error 1553 through bug #118151 (non-standard FK drift against the
+ * table). The statement always runs unmodified first and the guard is restored after the retry,
+ * so behaviour only changes for statements the bug would otherwise reject: legitimate 1553
+ * failures fail the retry as well, and without the variable (MariaDB, MySQL < 8.4) there is no
+ * retry.
  *
  * @see https://bugs.mysql.com/bug.php?id=118151
  *

--- a/src/Core/Framework/Migration/NonStandardFkGuard.php
+++ b/src/Core/Framework/Migration/NonStandardFkGuard.php
@@ -8,11 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * Executes DDL, retrying once with `restrict_fk_on_non_standard_key` relaxed when MySQL 8.4
- * rejects the statement with error 1553 through bug #118151 (non-standard FK drift against the
- * table). The statement always runs unmodified first and the guard is restored after the retry,
- * so behaviour only changes for statements the bug would otherwise reject: legitimate 1553
- * failures fail the retry as well, and without the variable (MariaDB, MySQL < 8.4) there is no
- * retry.
+ * rejects the statement with error 1553 through bug #118151. Legitimate 1553 failures fail the
+ * retry as well; without the variable (MariaDB, MySQL < 8.4) there is no retry.
  *
  * @see https://bugs.mysql.com/bug.php?id=118151
  *

--- a/src/Core/Migration/V6_6/Migration1707807389ChangeAvailableDefault.php
+++ b/src/Core/Migration/V6_6/Migration1707807389ChangeAvailableDefault.php
@@ -19,8 +19,6 @@ class Migration1707807389ChangeAvailableDefault extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            $connection->executeStatement('ALTER TABLE `product` CHANGE `available` `available` tinyint(1) NOT NULL DEFAULT \'0\';');
-        });
+        $this->executeDdlStatement($connection, 'ALTER TABLE `product` CHANGE `available` `available` tinyint(1) NOT NULL DEFAULT \'0\';');
     }
 }

--- a/src/Core/Migration/V6_6/Migration1714659357CanonicalProductVersion.php
+++ b/src/Core/Migration/V6_6/Migration1714659357CanonicalProductVersion.php
@@ -21,21 +21,18 @@ class Migration1714659357CanonicalProductVersion extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        // The non-standard FK replaced here is what makes MySQL 8.4 refuse the statements below.
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            $this->addColumn($connection, 'product', 'canonical_product_version_id', 'binary(16)', true, '0x0fa91ce3e96a4bc2be4bd9ce752c3425');
+        $this->addColumn($connection, 'product', 'canonical_product_version_id', 'binary(16)', true, '0x0fa91ce3e96a4bc2be4bd9ce752c3425');
 
-            // Safe to drop: the foreign key is re-added below with the versioned column pair.
-            $this->dropForeignKeyIfExists($connection, 'product', 'fk.product.canonical_product_id');
-            $this->dropIndexIfExists($connection, 'product', 'fk.product.canonical_product_id');
+        /** @phpstan-ignore shopware.dropStatement (As the foreign key is directly added again, the drop is fine in this case) */
+        $this->dropForeignKeyIfExists($connection, 'product', 'fk.product.canonical_product_id');
+        $this->dropIndexIfExists($connection, 'product', 'fk.product.canonical_product_id');
 
-            $connection->executeStatement('
-                ALTER TABLE `product`
-                ADD CONSTRAINT `fk.product.canonical_product_id`
-                FOREIGN KEY (`canonical_product_id` , `canonical_product_version_id`)
-                REFERENCES `product` (`id`, `version_id`)
-                ON DELETE SET NULL
-            ');
-        });
+        $this->executeDdlStatement($connection, '
+            ALTER TABLE `product`
+            ADD CONSTRAINT `fk.product.canonical_product_id`
+            FOREIGN KEY (`canonical_product_id` , `canonical_product_version_id`)
+            REFERENCES `product` (`id`, `version_id`)
+            ON DELETE SET NULL
+        ');
     }
 }

--- a/src/Core/Migration/V6_6/Migration1726049442UpdateVariantListingConfigInProductTable.php
+++ b/src/Core/Migration/V6_6/Migration1726049442UpdateVariantListingConfigInProductTable.php
@@ -64,8 +64,6 @@ class Migration1726049442UpdateVariantListingConfigInProductTable extends Migrat
             return;
         }
 
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            $connection->executeStatement('ALTER TABLE `product` MODIFY `display_group` VARCHAR(64) NULL');
-        });
+        $this->executeDdlStatement($connection, 'ALTER TABLE `product` MODIFY `display_group` VARCHAR(64) NULL');
     }
 }

--- a/src/Core/Migration/V6_7/Migration1756305375AddCategoriesIndexToProduct.php
+++ b/src/Core/Migration/V6_7/Migration1756305375AddCategoriesIndexToProduct.php
@@ -24,8 +24,6 @@ class Migration1756305375AddCategoriesIndexToProduct extends MigrationStep
             return;
         }
 
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            $connection->executeStatement('CREATE INDEX `idx.product.categories` ON `product` (`categories`)');
-        });
+        $this->executeDdlStatement($connection, 'CREATE INDEX `idx.product.categories` ON `product` (`categories`)');
     }
 }

--- a/src/Core/Migration/V6_7/Migration1761739065IncreaseProductWeightPrecision.php
+++ b/src/Core/Migration/V6_7/Migration1761739065IncreaseProductWeightPrecision.php
@@ -23,11 +23,7 @@ class Migration1761739065IncreaseProductWeightPrecision extends MigrationStep
             return;
         }
 
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            $connection->executeStatement(
-                'ALTER TABLE `product` MODIFY `weight` DECIMAL(15,6) UNSIGNED NULL'
-            );
-        });
+        $this->executeDdlStatement($connection, 'ALTER TABLE `product` MODIFY `weight` DECIMAL(15,6) UNSIGNED NULL');
     }
 
     private function isProductWeightUsingDefaultPrecision(Connection $connection): bool

--- a/src/Core/Migration/V6_7/Migration1763125891AddProductTypeColumn.php
+++ b/src/Core/Migration/V6_7/Migration1763125891AddProductTypeColumn.php
@@ -20,24 +20,22 @@ class Migration1763125891AddProductTypeColumn extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            if (!TableHelper::columnExists($connection, 'product', 'type')) {
-                $this->addColumn(
-                    $connection,
-                    'product',
-                    'type',
-                    'VARCHAR(32)',
-                    false,
-                    '\'physical\''
-                );
+        if (!TableHelper::columnExists($connection, 'product', 'type')) {
+            $this->addColumn(
+                $connection,
+                'product',
+                'type',
+                'VARCHAR(32)',
+                false,
+                '\'physical\''
+            );
 
-                $connection->executeStatement('CREATE INDEX `idx.product.type` ON `product` (`type`)');
-            }
+            $this->executeDdlStatement($connection, 'CREATE INDEX `idx.product.type` ON `product` (`type`)');
+        }
 
-            if (!TableHelper::indexExists($connection, 'product', 'idx.product.type')) {
-                $connection->executeStatement('CREATE INDEX `idx.product.type` ON `product` (`type`)');
-            }
-        });
+        if (!TableHelper::indexExists($connection, 'product', 'idx.product.type')) {
+            $this->executeDdlStatement($connection, 'CREATE INDEX `idx.product.type` ON `product` (`type`)');
+        }
 
         $batchSize = 5000;
 

--- a/src/Core/Migration/V6_7/Migration1774345867AddProductOpenGraphFields.php
+++ b/src/Core/Migration/V6_7/Migration1774345867AddProductOpenGraphFields.php
@@ -23,47 +23,46 @@ class Migration1774345867AddProductOpenGraphFields extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            $this->addColumn(
-                connection: $connection,
-                table: 'product',
-                column: 'open_graph_media_id',
-                type: 'BINARY(16)',
-                nullable: true,
-                default: 'NULL',
+        $this->addColumn(
+            connection: $connection,
+            table: 'product',
+            column: 'open_graph_media_id',
+            type: 'BINARY(16)',
+            nullable: true,
+            default: 'NULL',
+        );
+
+        $this->addColumn(
+            connection: $connection,
+            table: 'product_translation',
+            column: 'og_title',
+            type: 'VARCHAR(255)',
+            nullable: true,
+            default: 'NULL',
+        );
+
+        $this->addColumn(
+            connection: $connection,
+            table: 'product_translation',
+            column: 'og_description',
+            type: 'VARCHAR(255)',
+            nullable: true,
+            default: 'NULL',
+        );
+
+        if (!$this->indexExists($connection, 'product', 'fk.product.open_graph_media_id')) {
+            $this->executeDdlStatement(
+                $connection,
+                'ALTER TABLE `product`
+                ADD CONSTRAINT `fk.product.open_graph_media_id`
+                    FOREIGN KEY (`open_graph_media_id`)
+                    REFERENCES `media` (`id`) ON DELETE SET NULL ON UPDATE CASCADE'
             );
+        }
 
-            $this->addColumn(
-                connection: $connection,
-                table: 'product_translation',
-                column: 'og_title',
-                type: 'VARCHAR(255)',
-                nullable: true,
-                default: 'NULL',
-            );
-
-            $this->addColumn(
-                connection: $connection,
-                table: 'product_translation',
-                column: 'og_description',
-                type: 'VARCHAR(255)',
-                nullable: true,
-                default: 'NULL',
-            );
-
-            if (!$this->indexExists($connection, 'product', 'fk.product.open_graph_media_id')) {
-                $connection->executeStatement(
-                    'ALTER TABLE `product`
-                    ADD CONSTRAINT `fk.product.open_graph_media_id`
-                        FOREIGN KEY (`open_graph_media_id`)
-                        REFERENCES `media` (`id`) ON DELETE SET NULL ON UPDATE CASCADE'
-                );
-            }
-
-            if (!TableHelper::columnExists($connection, 'product', 'openGraphMedia')) {
-                $this->updateInheritance($connection, 'product', 'openGraphMedia');
-            }
-        });
+        if (!TableHelper::columnExists($connection, 'product', 'openGraphMedia')) {
+            $this->updateInheritance($connection, 'product', 'openGraphMedia');
+        }
 
         $this->registerIndexer($connection, 'product.indexer', ['product.inheritance']);
     }

--- a/src/Core/Migration/V6_7/Migration1775200001IncreaseProductDisplayGroupLength.php
+++ b/src/Core/Migration/V6_7/Migration1775200001IncreaseProductDisplayGroupLength.php
@@ -36,8 +36,6 @@ class Migration1775200001IncreaseProductDisplayGroupLength extends MigrationStep
             return;
         }
 
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            $connection->executeStatement('ALTER TABLE `product` MODIFY `display_group` VARCHAR(64) NULL');
-        });
+        $this->executeDdlStatement($connection, 'ALTER TABLE `product` MODIFY `display_group` VARCHAR(64) NULL');
     }
 }

--- a/src/Core/Migration/V6_8/Migration1763125892RemoveProductStatesColumn.php
+++ b/src/Core/Migration/V6_8/Migration1763125892RemoveProductStatesColumn.php
@@ -25,8 +25,6 @@ class Migration1763125892RemoveProductStatesColumn extends MigrationStep
 
     public function updateDestructive(Connection $connection): void
     {
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            $this->dropColumnIfExists($connection, 'product', 'states');
-        });
+        $this->dropColumnIfExists($connection, 'product', 'states');
     }
 }

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Migration/NonStandardFkGuardRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Migration/NonStandardFkGuardRuleTest.php
@@ -19,7 +19,7 @@ class NonStandardFkGuardRuleTest extends RuleTestCase
 {
     public function testRule(): void
     {
-        $message = 'DDL against "product" must run inside MigrationStep::withRelaxedNonStandardFkGuard(), otherwise it '
+        $message = 'Raw DDL against "product" must go through MigrationStep::executeDdlStatement(), otherwise it '
             . 'fails on MySQL 8.4 for the shops that carry non-standard foreign key drift against that '
             . 'table (MySQL bug #118151).';
 

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NonStandardFkGuardRule/Migration1785000001UnguardedDdl.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NonStandardFkGuardRule/Migration1785000001UnguardedDdl.php
@@ -21,10 +21,13 @@ class Migration1785000001UnguardedDdl extends MigrationStep
 
         $connection->executeStatement('CREATE INDEX `idx.product.foo` ON `product` (`foo`)');
 
-        $this->dropColumnIfExists($connection, 'product', 'bar');
+        $connection->executeStatement('DROP INDEX `idx.product.foo` ON `product`');
 
         // Not in TABLES_WITH_KNOWN_DRIFT, so not reported
         $connection->executeStatement('ALTER TABLE `order_line_item` ADD COLUMN `foo` VARCHAR(32) NULL');
         $connection->executeStatement('ALTER TABLE `media` ADD COLUMN `foo` VARCHAR(32) NULL');
+
+        // Not DDL, so not reported
+        $connection->executeStatement('UPDATE `product` SET `foo` = NULL');
     }
 }

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NonStandardFkGuardRule/Migration1785000002GuardedDdl.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NonStandardFkGuardRule/Migration1785000002GuardedDdl.php
@@ -17,17 +17,16 @@ class Migration1785000002GuardedDdl extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            $connection->executeStatement('ALTER TABLE `product` ADD COLUMN `foo` VARCHAR(32) NULL');
+        $this->executeDdlStatement($connection, 'ALTER TABLE `product` ADD COLUMN `foo` VARCHAR(32) NULL');
 
-            $this->dropColumnIfExists($connection, 'product', 'bar');
-        });
+        $this->executeDdlStatement($connection, 'CREATE INDEX `idx.product.foo` ON `product` (`foo`)');
+
+        // The MigrationStep DDL helpers run through the guard themselves
+        $this->addColumn($connection, 'product', 'bar', 'VARCHAR(32)');
     }
 
     public function updateDestructive(Connection $connection): void
     {
-        $this->withRelaxedNonStandardFkGuard($connection, function () use ($connection): void {
-            $this->dropColumnIfExists($connection, 'product', 'foo');
-        });
+        $this->dropColumnIfExists($connection, 'product', 'foo');
     }
 }

--- a/tests/devops/Core/Migration/NonStandardFkGuardTest.php
+++ b/tests/devops/Core/Migration/NonStandardFkGuardTest.php
@@ -106,6 +106,16 @@ class NonStandardFkGuardTest extends TestCase
         }
     }
 
+    public function testExecuteDdlStatementRetriesWithRelaxedGuard(): void
+    {
+        // Direct probe for the retry helper: the raw ALTER trips bug #118151 first, the retry with
+        // the guard relaxed must succeed and restore the guard. tearDown drops the probe column.
+        (new ProbeColumnMigration())->update($this->connection);
+
+        static::assertTrue(TableHelper::columnExists($this->connection, 'product', '_fk_guard_probe'));
+        $this->assertGuardRestored();
+    }
+
     public function testUnguardedDdlStillFailsSoTheFixtureStaysMeaningful(): void
     {
         // Regression witness: if this stops throwing, the fixture no longer reproduces the bug and
@@ -177,5 +187,21 @@ class NonStandardFkGuardTest extends TestCase
         } finally {
             $this->connection->executeStatement('SET SESSION restrict_fk_on_non_standard_key = ON');
         }
+    }
+}
+
+/**
+ * @internal
+ */
+class ProbeColumnMigration extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->executeDdlStatement($connection, 'ALTER TABLE `product` ADD COLUMN `_fk_guard_probe` VARCHAR(8) NULL');
     }
 }

--- a/tests/unit/Core/Framework/Migration/NonStandardFkGuardTest.php
+++ b/tests/unit/Core/Framework/Migration/NonStandardFkGuardTest.php
@@ -1,0 +1,157 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\DriverException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\NonStandardFkGuard;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(NonStandardFkGuard::class)]
+class NonStandardFkGuardTest extends TestCase
+{
+    private const DDL = 'ALTER TABLE `product` ADD COLUMN `foo` VARCHAR(32) NULL';
+
+    private const ER_DROP_INDEX_FK = 1553;
+
+    #[TestDox('a succeeding statement runs unmodified, without touching the guard')]
+    public function testRunsStatementUnmodifiedWhenItSucceeds(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('executeStatement')->willReturnCallback(function (string $sql): int {
+            static::assertSame(self::DDL, $sql);
+
+            return 0;
+        });
+        $connection->expects($this->never())->method('fetchAssociative');
+
+        NonStandardFkGuard::executeDdl($connection, self::DDL);
+    }
+
+    #[TestDox('failures other than error 1553 are rethrown without a retry')]
+    public function testRethrowsOtherFailuresWithoutRetry(): void
+    {
+        $failure = new FakeDriverException(1091, 'Can\'t DROP INDEX `foo`; check that it exists');
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('executeStatement')->willThrowException($failure);
+        $connection->expects($this->never())->method('fetchAssociative');
+
+        $this->expectExceptionObject($failure);
+
+        NonStandardFkGuard::executeDdl($connection, self::DDL);
+    }
+
+    /**
+     * @param array<string, string>|false $guardState
+     */
+    #[TestDox('error 1553 is rethrown when the guard cannot explain the failure')]
+    #[DataProvider('unexplainableGuardStates')]
+    public function testRethrowsWhenGuardCannotExplainTheFailure(array|false $guardState): void
+    {
+        $failure = new FakeDriverException(self::ER_DROP_INDEX_FK, 'Cannot drop index \'idx\': needed in a foreign key constraint');
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('executeStatement')->willThrowException($failure);
+        $connection->expects($this->once())->method('fetchAssociative')->willReturn($guardState);
+
+        $this->expectExceptionObject($failure);
+
+        NonStandardFkGuard::executeDdl($connection, self::DDL);
+    }
+
+    /**
+     * @return \Generator<string, array{array<string, string>|false}>
+     */
+    public static function unexplainableGuardStates(): \Generator
+    {
+        yield 'variable absent (MariaDB, MySQL < 8.4)' => [false];
+        yield 'guard already relaxed' => [['Variable_name' => 'restrict_fk_on_non_standard_key', 'Value' => 'OFF']];
+    }
+
+    #[TestDox('error 1553 with the guard ON relaxes the guard, retries, and restores the guard')]
+    public function testRetriesWithRelaxedGuardAndRestoresIt(): void
+    {
+        $statements = [];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->exactly(4))->method('executeStatement')
+            ->willReturnCallback(function (string $sql) use (&$statements): int {
+                $statements[] = $sql;
+
+                if (\count($statements) === 1) {
+                    throw new FakeDriverException(self::ER_DROP_INDEX_FK, 'Cannot drop index \'<unknown key name>\': needed in a foreign key constraint');
+                }
+
+                return 0;
+            });
+        $connection->expects($this->once())->method('fetchAssociative')
+            ->willReturn(['Variable_name' => 'restrict_fk_on_non_standard_key', 'Value' => 'ON']);
+
+        NonStandardFkGuard::executeDdl($connection, self::DDL);
+
+        static::assertSame([
+            self::DDL,
+            'SET SESSION restrict_fk_on_non_standard_key = OFF',
+            self::DDL,
+            'SET SESSION restrict_fk_on_non_standard_key = ON',
+        ], $statements);
+    }
+
+    #[TestDox('a failing retry surfaces its failure and still restores the guard')]
+    public function testRestoresGuardWhenRetryFailsToo(): void
+    {
+        $retryFailure = new FakeDriverException(self::ER_DROP_INDEX_FK, 'Cannot drop index \'idx\': needed in a foreign key constraint');
+        $statements = [];
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->exactly(4))->method('executeStatement')
+            ->willReturnCallback(function (string $sql) use (&$statements, $retryFailure): int {
+                $statements[] = $sql;
+
+                if ($sql === self::DDL) {
+                    throw \count($statements) === 1
+                        ? new FakeDriverException(self::ER_DROP_INDEX_FK, 'Cannot drop index \'idx\': needed in a foreign key constraint')
+                        : $retryFailure;
+                }
+
+                return 0;
+            });
+        $connection->expects($this->once())->method('fetchAssociative')
+            ->willReturn(['Variable_name' => 'restrict_fk_on_non_standard_key', 'Value' => 'ON']);
+
+        $thrown = null;
+
+        try {
+            NonStandardFkGuard::executeDdl($connection, self::DDL);
+        } catch (DriverException $thrown) {
+        }
+
+        static::assertSame($retryFailure, $thrown);
+        static::assertSame('SET SESSION restrict_fk_on_non_standard_key = ON', end($statements), 'The guard must be restored even when the retry fails');
+    }
+}
+
+/**
+ * Doctrine's DriverException can only be built from a live driver exception; bypass that.
+ *
+ * @internal
+ */
+class FakeDriverException extends DriverException
+{
+    public function __construct(
+        int $errorCode,
+        string $message
+    ) {
+        $this->code = $errorCode;
+        $this->message = $message;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

POC to avoid closure and narrow the check


Follow-up to the review question on #18631 (less permissive than a closure): the guard should only ever be relaxed for a single DDL statement, and only when it actually blocked it.

### 2. What does this change do, exactly?

- Replaces `withRelaxedNonStandardFkGuard(Connection, \Closure)` with `executeDdlStatement(Connection, string $sql)`: run the statement as-is, and only on error 1553 with the guard `ON` relax it for one retry, restoring it afterwards. Legitimate 1553 failures fail the retry too; the retry is safe because a failed DDL statement applied nothing (atomic DDL).
- Logic lives in `NonStandardFkGuard::executeDdl()`; `addColumn()`, `dropColumnIfExists()`, `dropForeignKeyIfExists()`, `dropIndexIfExists()` and `updateInheritance()` route through it, so helper-only migrations need no call at all.
- The 9 migrations go back to their unwrapped shape; raw DDL lines become `executeDdlStatement()`.
- `NonStandardFkGuardRule` now only flags raw `executeStatement()` DDL against drifted tables, dropping the "inside some closure" heuristic.
- Unit test for the retry logic; the devops regression test also probes `executeDdlStatement()` directly.

### 3. Describe each step to reproduce the issue or behaviour.

Same as #18631; covered by `tests/devops/Core/Migration/NonStandardFkGuardTest.php` in the `mysql:8.4` lane.

### 4. Please link to the relevant issues (if any).

- relates #18631

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
