### PR TITLE
fix: preserve paginated CMS category assignments

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
@@ -20,6 +20,7 @@ export default {
         'selection-add',
         'selection-remove',
         'categories-load-more',
+        'update:categoriesCollection',
     ],
 
     props: {
@@ -217,7 +218,8 @@ export default {
 
             if (this.pageId) {
                 this.globalCategoryRepository.searchIds(this.pageCategoryCriteria).then((result) => {
-                    this.selectedCategoriesTotal = result.total;
+                    this.selectedCategories = result?.data ?? [];
+                    this.selectedCategoriesTotal = result?.total ?? 0;
                 });
             }
         },
@@ -244,7 +246,9 @@ export default {
                     this.isFetching = false;
 
                     if (this.pageId && searchResult[0].cmsPageId === this.pageId) {
-                        this.selectedCategories.push(searchResult[0].id);
+                        if (!this.selectedCategories.includes(searchResult[0].id)) {
+                            this.selectedCategories.push(searchResult[0].id);
+                        }
                     }
 
                     return Promise.resolve();
@@ -255,7 +259,9 @@ export default {
                     this.categories.add(category);
 
                     if (this.pageId && category.cmsPageId === this.pageId) {
-                        this.selectedCategories.push(category.id);
+                        if (!this.selectedCategories.includes(category.id)) {
+                            this.selectedCategories.push(category.id);
+                        }
                     }
                 });
 
@@ -298,6 +304,8 @@ export default {
                     this.$emit('selection-add', item);
                 }
 
+                this.emitCategoriesCollectionUpdate();
+
                 if (this.singleSelect) {
                     this.isExpanded = false;
                 }
@@ -323,11 +331,14 @@ export default {
                 this.selectedCategoriesTotal -= 1;
             }
 
-            if (item.data) {
-                this.$emit('selection-remove', item.data);
-            } else {
-                this.$emit('selection-remove', item);
-            }
+            const removedItem = item.data ?? item;
+
+            this.emitCategoriesCollectionUpdate();
+            this.$emit('selection-remove', removedItem);
+        },
+
+        emitCategoriesCollectionUpdate() {
+            this.$emit('update:categoriesCollection', this.categoriesCollection);
         },
 
         searchCategories(term) {

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
@@ -218,8 +218,8 @@ export default {
 
             if (this.pageId) {
                 this.globalCategoryRepository.searchIds(this.pageCategoryCriteria).then((result) => {
-                    this.selectedCategories = result?.data ?? [];
-                    this.selectedCategoriesTotal = result?.total ?? 0;
+                    this.selectedCategories = result.data;
+                    this.selectedCategoriesTotal = result.total;
                 });
             }
         },
@@ -245,10 +245,12 @@ export default {
                     this.categories = searchResult;
                     this.isFetching = false;
 
-                    if (this.pageId && searchResult[0].cmsPageId === this.pageId) {
-                        if (!this.selectedCategories.includes(searchResult[0].id)) {
-                            this.selectedCategories.push(searchResult[0].id);
-                        }
+                    if (
+                        this.pageId &&
+                        searchResult[0].cmsPageId === this.pageId &&
+                        !this.selectedCategories.includes(searchResult[0].id)
+                    ) {
+                        this.selectedCategories.push(searchResult[0].id);
                     }
 
                     return Promise.resolve();
@@ -258,10 +260,12 @@ export default {
                 searchResult.forEach((category) => {
                     this.categories.add(category);
 
-                    if (this.pageId && category.cmsPageId === this.pageId) {
-                        if (!this.selectedCategories.includes(category.id)) {
-                            this.selectedCategories.push(category.id);
-                        }
+                    if (
+                        this.pageId &&
+                        category.cmsPageId === this.pageId &&
+                        !this.selectedCategories.includes(category.id)
+                    ) {
+                        this.selectedCategories.push(category.id);
                     }
                 });
 

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.spec.js
@@ -185,6 +185,8 @@ describe('src/app/component/entity/sw-category-tree-field', () => {
         wrapper.vm.removeItem(intitalCategories[0]);
 
         expect(wrapper.vm.categoriesCollection).toHaveLength(1);
+        expect(wrapper.emitted('update:categoriesCollection')).toHaveLength(1);
+        expect(wrapper.emitted('update:categoriesCollection')[0][0]).toHaveLength(1);
     });
 
     it('should display more the category items', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
@@ -442,15 +442,12 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         discardCategoryChanges() {
-            const categories = this.page.categories!;
-            const originCategories = this.page.getOrigin().categories!;
-
             this.page.categories = new EntityCollection(
-                originCategories.source || categories.source,
-                originCategories.entity || categories.entity,
+                this.page.categories!.source,
+                this.page.categories!.entity,
                 Shopware.Context.api,
                 null,
-                [...originCategories],
+                [...this.page.getOrigin().categories],
             );
             this.removedCategoryIds = [];
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
@@ -37,7 +37,6 @@ export default Shopware.Component.wrapComponentConfig({
     data() {
         return {
             shopPageSalesChannelId: null as string | null,
-            previousCategories: [] as Entity<'category'>[],
             previousCategoryIds: [] as string[],
             previousLandingPages: [] as Entity<'landing_page'>[],
             previousLandingPageIds: [] as string[],
@@ -58,6 +57,7 @@ export default Shopware.Component.wrapComponentConfig({
             hasLandingPagesWithAssignedLayouts: false,
             previousProducts: [] as Entity<'product'>[],
             previousProductIds: [] as string[],
+            removedCategoryIds: [] as string[],
             categoryIndex: 1,
             isCategoriesLoading: false,
             activeTab: 'categories',
@@ -193,8 +193,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     methods: {
         createdComponent() {
-            this.previousCategories = [...this.page.categories!];
-            this.previousCategoryIds = this.page.categories!.getIds();
+            this.previousCategoryIds = [...this.page.getOrigin().categories!.getIds()];
 
             this.previousLandingPages = [...this.page.landingPages!];
             this.previousLandingPageIds = this.page.landingPages!.getIds();
@@ -443,13 +442,17 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         discardCategoryChanges() {
+            const categories = this.page.categories!;
+            const originCategories = this.page.getOrigin().categories!;
+
             this.page.categories = new EntityCollection(
-                this.page.categories!.source,
-                this.page.categories!.entity,
+                originCategories.source || categories.source,
+                originCategories.entity || categories.entity,
                 Shopware.Context.api,
                 null,
-                this.previousCategories ?? [],
+                [...originCategories],
             );
+            this.removedCategoryIds = [];
         },
 
         discardLandingPageChanges() {
@@ -511,6 +514,32 @@ export default Shopware.Component.wrapComponentConfig({
             void this.loadSystemConfig();
         },
 
+        onCategoryAdd(category: Entity<'category'>) {
+            this.removedCategoryIds = this.removedCategoryIds.filter((id) => id !== category.id);
+        },
+
+        onCategoryRemove(category: Entity<'category'>) {
+            if (!this.removedCategoryIds.includes(category.id)) {
+                this.removedCategoryIds.push(category.id);
+            }
+
+            const originCategories = this.page.getOrigin().categories!;
+
+            if (category.cmsPageId === this.page.id && !originCategories.has(category.id)) {
+                originCategories.add(category);
+            }
+
+            const categories = this.page.categories!;
+            const removedCategoryIds = new Set(this.removedCategoryIds);
+
+            originCategories.forEach((item) => {
+                if (!removedCategoryIds.has(item.id) && !categories.has(item.id)) {
+                    categories.add(item);
+                }
+            });
+            this.previousCategoryIds = [...originCategories.getIds()];
+        },
+
         async onExtraCategories() {
             this.isCategoriesLoading = true;
             this.categoryIndex += 1;
@@ -522,7 +551,20 @@ export default Shopware.Component.wrapComponentConfig({
             const result = await this.categoryRepository.search(criteria);
 
             if (result?.length > 0) {
-                this.page.categories!.push(...result);
+                const categories = this.page.categories!;
+                const originCategories = this.page.getOrigin().categories!;
+
+                result.forEach((category) => {
+                    if (!this.removedCategoryIds.includes(category.id) && !categories.has(category.id)) {
+                        categories.add(category);
+                    }
+
+                    if (!originCategories.has(category.id)) {
+                        originCategories.add(category);
+                    }
+                });
+
+                this.previousCategoryIds = [...originCategories.getIds()];
             }
 
             this.isCategoriesLoading = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
@@ -447,7 +447,7 @@ export default Shopware.Component.wrapComponentConfig({
                 this.page.categories!.entity,
                 Shopware.Context.api,
                 null,
-                [...this.page.getOrigin().categories],
+                [...this.page.getOrigin().categories!],
             );
             this.removedCategoryIds = [];
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/sw-cms-layout-assignment-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/sw-cms-layout-assignment-modal.html.twig
@@ -84,13 +84,15 @@
             {% block sw_cms_layout_assignment_modal_mt_category_select_field %}
             <sw-category-tree-field
                 key="categorySelect"
-                :categories-collection="page.categories"
+                v-model:categories-collection="page.categories"
                 :label="$t('sw-cms.components.cmsLayoutAssignmentModal.labelCategories')"
                 :placeholder="$t('sw-cms.components.cmsLayoutAssignmentModal.placeholderCategories')"
                 :page-id="page.id"
                 :is-categories-loading="isCategoriesLoading"
                 class="sw-cms-layout-assignment-modal__category-select"
                 @categories-load-more="onExtraCategories"
+                @selection-add="onCategoryAdd"
+                @selection-remove="onCategoryRemove"
             />
             {% endblock %}
         </template>
@@ -277,13 +279,15 @@
                     {% block sw_cms_layout_assignment_modal_category_select_field %}
                     <sw-category-tree-field
                         key="categorySelect"
-                        :categories-collection="page.categories"
+                        v-model:categories-collection="page.categories"
                         :label="$t('sw-cms.components.cmsLayoutAssignmentModal.labelCategories')"
                         :placeholder="$t('sw-cms.components.cmsLayoutAssignmentModal.placeholderCategories')"
                         :page-id="page.id"
                         :is-categories-loading="isCategoriesLoading"
                         class="sw-cms-layout-assignment-modal__category-select"
                         @categories-load-more="onExtraCategories"
+                        @selection-add="onCategoryAdd"
+                        @selection-remove="onCategoryRemove"
                     />
                     {% endblock %}
                 </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/sw-cms-layout-assignment-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/sw-cms-layout-assignment-modal.spec.js
@@ -1283,26 +1283,33 @@ describe('module/sw-cms/component/sw-cms-layout-assignment-modal', () => {
         expect(wrapper.vm.page.categories).toBe(initialCategories);
     });
 
-    it('should preserve unloaded categories when removing one loaded category', async () => {
+    it('should preserve paginated category assignments when removing a loaded category', async () => {
         const wrapper = await createWrapper();
-        const originCategories = wrapper.vm.page.getOrigin().categories;
-
-        Array.from({ length: 47 }, (_, index) => {
-            originCategories.add({
+        const extraCategories = Array.from({ length: 50 }, (_, index) => {
+            return {
                 id: `extra-category-${index}`,
                 cmsPageId: wrapper.vm.page.id,
-            });
+            };
         });
+        const removedCategory = extraCategories.at(-1);
 
-        wrapper.vm.page.categories.remove('uuid3');
-        wrapper.vm.onCategoryRemove({
-            id: 'uuid3',
-            cmsPageId: wrapper.vm.page.id,
-        });
+        wrapper.vm.categoryRepository.search = jest
+            .fn()
+            .mockResolvedValueOnce(extraCategories.slice(0, 25))
+            .mockResolvedValueOnce(extraCategories.slice(25));
 
-        expect(wrapper.vm.page.categories).toHaveLength(49);
-        expect(wrapper.vm.page.categories.has('uuid3')).toBe(false);
-        expect(wrapper.vm.page.categories.has('extra-category-46')).toBe(true);
+        await wrapper.vm.onExtraCategories();
+        await wrapper.vm.onExtraCategories();
+
+        wrapper.vm.page.categories.remove(removedCategory.id);
+        wrapper.vm.onCategoryRemove(removedCategory);
+
+        expect(wrapper.vm.page.getOrigin().categories).toHaveLength(53);
+        expect(wrapper.vm.page.categories).toHaveLength(52);
+        expect(wrapper.vm.page.categories.has(removedCategory.id)).toBe(false);
+
+        await expect(wrapper.vm.validateCategories()).rejects.toBeUndefined();
+        expect(wrapper.vm.hasDeletedCategories).toBe(true);
     });
 
     it('should not re-add a removed category when loading another category page', async () => {
@@ -1332,15 +1339,5 @@ describe('module/sw-cms/component/sw-cms-layout-assignment-modal', () => {
 
         expect(wrapper.vm.page.categories).toHaveLength(5);
         expect(wrapper.vm.page.getOrigin().categories).toHaveLength(5);
-    });
-
-    it('should validate deletion after loading more categories', async () => {
-        const wrapper = await createWrapper();
-
-        await wrapper.vm.onExtraCategories();
-        wrapper.vm.page.categories.remove('uuid3');
-
-        await expect(wrapper.vm.validateCategories()).rejects.toBeUndefined();
-        expect(wrapper.vm.hasDeletedCategories).toBe(true);
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/sw-cms-layout-assignment-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/sw-cms-layout-assignment-modal.spec.js
@@ -100,6 +100,10 @@ async function createWrapper(
     systemConfigApiServiceOverrides = {},
     { featureActive = false } = {},
 ) {
+    const origin = {
+        categories: new EntityCollection(null, null, Shopware.Context.api, new Criteria(1, 25), mockCategories),
+    };
+
     return mount(
         await wrapTestComponent('sw-cms-layout-assignment-modal', {
             sync: true,
@@ -119,6 +123,7 @@ async function createWrapper(
                     ),
                     type: layoutType,
                     id: 'uuid007',
+                    getOrigin: () => origin,
                 },
             },
             global: {
@@ -371,13 +376,11 @@ describe('module/sw-cms/component/sw-cms-layout-assignment-modal', () => {
     it('should store previous categories on component creation', async () => {
         const wrapper = await createWrapper();
 
-        expect(wrapper.vm.previousCategories).toEqual(mockCategories);
-        expect(wrapper.vm.previousCategoryIds).toEqual(
-            expect.arrayContaining([
-                'uuid1',
-                'uuid2',
-            ]),
-        );
+        expect(wrapper.vm.previousCategoryIds).toEqual([
+            'uuid1',
+            'uuid2',
+            'uuid3',
+        ]);
     });
 
     it('should add categories', async () => {
@@ -1267,6 +1270,7 @@ describe('module/sw-cms/component/sw-cms-layout-assignment-modal', () => {
 
     it('should increment categoryIndex and update page.categories', async () => {
         const wrapper = await createWrapper();
+        const initialCategories = wrapper.vm.page.categories;
 
         expect(wrapper.vm.categoryIndex).toBe(1);
         expect(wrapper.vm.page.categories).toHaveLength(3);
@@ -1276,5 +1280,67 @@ describe('module/sw-cms/component/sw-cms-layout-assignment-modal', () => {
 
         expect(wrapper.vm.categoryIndex).toBe(2);
         expect(wrapper.vm.page.categories).toHaveLength(5);
+        expect(wrapper.vm.page.categories).toBe(initialCategories);
+    });
+
+    it('should preserve unloaded categories when removing one loaded category', async () => {
+        const wrapper = await createWrapper();
+        const originCategories = wrapper.vm.page.getOrigin().categories;
+
+        Array.from({ length: 47 }, (_, index) => {
+            originCategories.add({
+                id: `extra-category-${index}`,
+                cmsPageId: wrapper.vm.page.id,
+            });
+        });
+
+        wrapper.vm.page.categories.remove('uuid3');
+        wrapper.vm.onCategoryRemove({
+            id: 'uuid3',
+            cmsPageId: wrapper.vm.page.id,
+        });
+
+        expect(wrapper.vm.page.categories).toHaveLength(49);
+        expect(wrapper.vm.page.categories.has('uuid3')).toBe(false);
+        expect(wrapper.vm.page.categories.has('extra-category-46')).toBe(true);
+    });
+
+    it('should not re-add a removed category when loading another category page', async () => {
+        const wrapper = await createWrapper();
+        const removedCategory = {
+            id: 'uuid3',
+            cmsPageId: wrapper.vm.page.id,
+        };
+
+        wrapper.vm.page.categories.remove(removedCategory.id);
+        wrapper.vm.onCategoryRemove(removedCategory);
+        wrapper.vm.categoryRepository.search = jest.fn().mockResolvedValue([removedCategory]);
+
+        await wrapper.vm.onExtraCategories();
+
+        expect(wrapper.vm.page.categories.has(removedCategory.id)).toBe(false);
+    });
+
+    it('should restore the complete category baseline when discarding changes', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.vm.onExtraCategories();
+
+        expect(wrapper.vm.page.getOrigin().categories).toHaveLength(5);
+
+        wrapper.vm.discardCategoryChanges();
+
+        expect(wrapper.vm.page.categories).toHaveLength(5);
+        expect(wrapper.vm.page.getOrigin().categories).toHaveLength(5);
+    });
+
+    it('should validate deletion after loading more categories', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.vm.onExtraCategories();
+        wrapper.vm.page.categories.remove('uuid3');
+
+        await expect(wrapper.vm.validateCategories()).rejects.toBeUndefined();
+        expect(wrapper.vm.hasDeletedCategories).toBe(true);
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Removing a category assignment beyond the paging boundary is not persisted and the assignment reappears after reloading.

### 2. What does this change do, exactly?

Synchronizes the complete category association with the tree field while lazy-loading additional categories, ensuring that removals are included in the saved changeset.

### 3. Describe each step to reproduce the issue or behaviour.

1. Assign a Shopping Experience to more than 25 categories.
2. Open Layout Assignment and trigger lazy-loading of additional categories.
3. Remove a category from the loaded results and click Apply.
4. Reload the Shopping Experience.
5. The category assignment is still present.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #18388

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
