### PR TITLE
feat: allow app cookies to be bound to active payment methods

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -379,7 +379,7 @@ The administration media folder settings modal (`sw-media-modal-folder-settings`
 
 * `sw-media-modal-folder-settings__mediaFolder`
 * `sw-media-modal-folder-settings__configuration`
-### Manifest cookies can be bound to active payment methods
+### Cookies can be bound to active payment methods
 
 Cookies declared in an app's `manifest.xml` were always shown in the storefront cookie consent manager, even on sales channels where the app's payment methods are not offered. A cookie (both standalone and inside a group's `<entries>`) can now reference payment methods of the app via the repeatable `<active-payment-method>` element:
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -379,6 +379,19 @@ The administration media folder settings modal (`sw-media-modal-folder-settings`
 
 * `sw-media-modal-folder-settings__mediaFolder`
 * `sw-media-modal-folder-settings__configuration`
+### Manifest cookies can be bound to active payment methods
+
+Cookies declared in an app's `manifest.xml` were always shown in the storefront cookie consent manager, even on sales channels where the app's payment methods are not offered. A cookie (both standalone and inside a group's `<entries>`) can now reference payment methods of the app via the repeatable `<active-payment-method>` element:
+
+```xml
+<cookie>
+    <snippet-name>myApp.cookie.wallet</snippet-name>
+    <cookie>my-app-wallet</cookie>
+    <active-payment-method>wallet</active-payment-method>
+</cookie>
+```
+
+The cookie is only added to the consent manager if at least one of the referenced payment methods is active in the current sales channel. The wildcard `*` matches any payment method of the app, so SDK-level cookies don't need to enumerate every identifier. Cookies without the element keep the previous always-on behavior. This gives apps the equivalent of what plugins can already do with `CookieGroupCollectEvent`.
 
 ## Hosting & Configuration
 

--- a/src/Core/Framework/App/AppEntity.php
+++ b/src/Core/Framework/App/AppEntity.php
@@ -28,7 +28,7 @@ use Shopware\Core\System\TaxProvider\TaxProviderCollection;
 
 /**
  * @phpstan-type Module array{name: string, label: array<string, string>, parent: string, source?: string|null, position: int}
- * @phpstan-type Cookie array{snippet_name: string, snippet_description?: string, cookie?: string, value?: string, expiration?: string, entries?: list<array{snippet_name: string, snippet_description?: string, cookie: string, value?: string, expiration?: string}>}
+ * @phpstan-type Cookie array{snippet_name: string, snippet_description?: string, cookie?: string, value?: string, expiration?: string, active_payment_methods?: list<string>, entries?: list<array{snippet_name: string, snippet_description?: string, cookie: string, value?: string, expiration?: string, active_payment_methods?: list<string>}>}
  *
  * @phpstan-import-type SourceConfig from AppDefinition
  */

--- a/src/Core/Framework/App/Cookie/AppCookieCollectListener.php
+++ b/src/Core/Framework/App/Cookie/AppCookieCollectListener.php
@@ -14,10 +14,8 @@ use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\Log\Package;
 
@@ -30,6 +28,8 @@ use Shopware\Core\Framework\Log\Package;
 class AppCookieCollectListener
 {
     private const ANY_PAYMENT_METHOD = '*';
+
+    private const APP_HANDLER_PREFIX = 'app\\';
 
     /**
      * @param EntityRepository<AppCollection> $appRepository
@@ -121,42 +121,17 @@ class AppCookieCollectListener
     }
 
     /**
-     * @return array<string, true> handler identifiers of the referenced payment methods active in the sales channel
+     * @return array<string, true> handler identifiers of the app payment methods active in the sales channel
      */
     private function fetchActiveHandlerIdentifiers(AppCollection $apps, CookieGroupCollectEvent $event): array
     {
-        $handlerIdentifiers = [];
-        $wildcardAppNames = [];
-
-        foreach ($apps as $app) {
-            foreach ($app->getCookies() as $cookie) {
-                foreach ([$cookie, ...($cookie['entries'] ?? [])] as $item) {
-                    foreach ($item['active_payment_methods'] ?? [] as $identifier) {
-                        if ($identifier === self::ANY_PAYMENT_METHOD) {
-                            $wildcardAppNames[$app->getName()] = true;
-                        } else {
-                            $handlerIdentifiers[] = self::buildHandlerIdentifier($app->getName(), $identifier);
-                        }
-                    }
-                }
-            }
-        }
-
-        $identifierFilters = [];
-        if ($handlerIdentifiers !== []) {
-            $identifierFilters[] = new EqualsAnyFilter('handlerIdentifier', array_values(array_unique($handlerIdentifiers)));
-        }
-        foreach (array_keys($wildcardAppNames) as $appName) {
-            $identifierFilters[] = new PrefixFilter('handlerIdentifier', self::buildHandlerIdentifier($appName, ''));
-        }
-
-        if ($identifierFilters === []) {
+        if (!$this->hasPaymentMethodConditions($apps)) {
             return [];
         }
 
         $criteria = new Criteria();
         $criteria->addFilter(
-            new OrFilter($identifierFilters),
+            new PrefixFilter('handlerIdentifier', self::APP_HANDLER_PREFIX),
             new EqualsFilter('active', true),
             new EqualsFilter('salesChannels.id', $event->getSalesChannelContext()->getSalesChannelId())
         );
@@ -169,6 +144,21 @@ class AppCookieCollectListener
         }
 
         return $activeHandlerIdentifiers;
+    }
+
+    private function hasPaymentMethodConditions(AppCollection $apps): bool
+    {
+        foreach ($apps as $app) {
+            foreach ($app->getCookies() as $cookie) {
+                foreach ([$cookie, ...($cookie['entries'] ?? [])] as $item) {
+                    if (($item['active_payment_methods'] ?? []) !== []) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -233,6 +223,6 @@ class AppCookieCollectListener
     private static function buildHandlerIdentifier(string $appName, string $identifier): string
     {
         // must match PaymentMethodLifecycleHandler
-        return \sprintf('app\\%s_%s', $appName, $identifier);
+        return \sprintf('%s%s_%s', self::APP_HANDLER_PREFIX, $appName, $identifier);
     }
 }

--- a/src/Core/Framework/App/Cookie/AppCookieCollectListener.php
+++ b/src/Core/Framework/App/Cookie/AppCookieCollectListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopware\Core\Framework\App\Cookie;
 
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
 use Shopware\Core\Content\Cookie\Struct\CookieEntry;
 use Shopware\Core\Content\Cookie\Struct\CookieEntryCollection;
@@ -13,8 +14,11 @@ use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -25,11 +29,15 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('framework')]
 class AppCookieCollectListener
 {
+    private const ANY_PAYMENT_METHOD = '*';
+
     /**
      * @param EntityRepository<AppCollection> $appRepository
+     * @param EntityRepository<PaymentMethodCollection> $paymentMethodRepository
      */
     public function __construct(
         private readonly EntityRepository $appRepository,
+        private readonly EntityRepository $paymentMethodRepository,
     ) {
     }
 
@@ -43,8 +51,12 @@ class AppCookieCollectListener
 
         $apps = $this->appRepository->search($criteria, $event->getContext())->getEntities();
 
+        $activeHandlerIdentifiers = $this->fetchActiveHandlerIdentifiers($apps, $event);
+
         foreach ($apps as $app) {
-            $this->addCookies($event->cookieGroupCollection, $app->getCookies());
+            $cookies = $this->filterCookies($app->getName(), $app->getCookies(), $activeHandlerIdentifiers);
+
+            $this->addCookies($event->cookieGroupCollection, $cookies);
         }
     }
 
@@ -106,5 +118,121 @@ class AppCookieCollectListener
                 }
             }
         }
+    }
+
+    /**
+     * @return array<string, true> handler identifiers of the referenced payment methods active in the sales channel
+     */
+    private function fetchActiveHandlerIdentifiers(AppCollection $apps, CookieGroupCollectEvent $event): array
+    {
+        $handlerIdentifiers = [];
+        $wildcardAppNames = [];
+
+        foreach ($apps as $app) {
+            foreach ($app->getCookies() as $cookie) {
+                foreach ([$cookie, ...($cookie['entries'] ?? [])] as $item) {
+                    foreach ($item['active_payment_methods'] ?? [] as $identifier) {
+                        if ($identifier === self::ANY_PAYMENT_METHOD) {
+                            $wildcardAppNames[$app->getName()] = true;
+                        } else {
+                            $handlerIdentifiers[] = self::buildHandlerIdentifier($app->getName(), $identifier);
+                        }
+                    }
+                }
+            }
+        }
+
+        $identifierFilters = [];
+        if ($handlerIdentifiers !== []) {
+            $identifierFilters[] = new EqualsAnyFilter('handlerIdentifier', array_values(array_unique($handlerIdentifiers)));
+        }
+        foreach (array_keys($wildcardAppNames) as $appName) {
+            $identifierFilters[] = new PrefixFilter('handlerIdentifier', self::buildHandlerIdentifier($appName, ''));
+        }
+
+        if ($identifierFilters === []) {
+            return [];
+        }
+
+        $criteria = new Criteria();
+        $criteria->addFilter(
+            new OrFilter($identifierFilters),
+            new EqualsFilter('active', true),
+            new EqualsFilter('salesChannels.id', $event->getSalesChannelContext()->getSalesChannelId())
+        );
+
+        $paymentMethods = $this->paymentMethodRepository->search($criteria, $event->getContext())->getEntities();
+
+        $activeHandlerIdentifiers = [];
+        foreach ($paymentMethods as $paymentMethod) {
+            $activeHandlerIdentifiers[$paymentMethod->getHandlerIdentifier()] = true;
+        }
+
+        return $activeHandlerIdentifiers;
+    }
+
+    /**
+     * @param list<Cookie> $cookies
+     * @param array<string, true> $activeHandlerIdentifiers
+     *
+     * @return list<Cookie>
+     */
+    private function filterCookies(string $appName, array $cookies, array $activeHandlerIdentifiers): array
+    {
+        $filtered = [];
+
+        foreach ($cookies as $cookie) {
+            if (!$this->isCookieAllowed($appName, $cookie, $activeHandlerIdentifiers)) {
+                continue;
+            }
+
+            if (\array_key_exists('entries', $cookie)) {
+                $cookie['entries'] = array_values(array_filter(
+                    $cookie['entries'],
+                    fn (array $entry): bool => $this->isCookieAllowed($appName, $entry, $activeHandlerIdentifiers),
+                ));
+            }
+
+            $filtered[] = $cookie;
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * @param array{active_payment_methods?: list<string>} $cookie
+     * @param array<string, true> $activeHandlerIdentifiers
+     */
+    private function isCookieAllowed(string $appName, array $cookie, array $activeHandlerIdentifiers): bool
+    {
+        $identifiers = $cookie['active_payment_methods'] ?? [];
+        if ($identifiers === []) {
+            return true;
+        }
+
+        foreach ($identifiers as $identifier) {
+            if ($identifier === self::ANY_PAYMENT_METHOD) {
+                $prefix = self::buildHandlerIdentifier($appName, '');
+                foreach (array_keys($activeHandlerIdentifiers) as $handlerIdentifier) {
+                    if (str_starts_with($handlerIdentifier, $prefix)) {
+                        return true;
+                    }
+                }
+
+                continue;
+            }
+
+            if (isset($activeHandlerIdentifiers[self::buildHandlerIdentifier($appName, $identifier)])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function buildHandlerIdentifier(string $appName, string $identifier): string
+    {
+        // must match PaymentMethodLifecycleHandler
+        return \sprintf('app\\%s_%s', $appName, $identifier);
     }
 }

--- a/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
+++ b/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
@@ -498,6 +498,15 @@
             <xs:element type="xs:string" name="cookie"/>
             <xs:element type="xs:string" name="value" minOccurs="0"/>
             <xs:element type="xs:int" name="expiration" minOccurs="0"/>
+            <xs:element type="xs:string" name="active-payment-method" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Identifier of a payment method of this app, or "*" for any payment method of this app.
+                        When given, the cookie is only shown if at least one referenced payment method is
+                        active in the current sales channel.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:choice>
     </xs:complexType>
     <xs:complexType name="cookie-group">

--- a/src/Core/Framework/App/Manifest/Xml/Cookie/Cookies.php
+++ b/src/Core/Framework/App/Manifest/Xml/Cookie/Cookies.php
@@ -17,6 +17,8 @@ class Cookies extends XmlElement
     private const VALUE_TAG = 'value';
     private const EXPIRATION_TAG = 'expiration';
     private const ENTRIES_TAG = 'entries';
+    private const ACTIVE_PAYMENT_METHOD_TAG = 'active-payment-method';
+    private const ACTIVE_PAYMENT_METHODS_KEY = 'active_payment_methods';
 
     /**
      * @var list<array<string, mixed>>
@@ -66,6 +68,10 @@ class Cookies extends XmlElement
 
             if ($child->tagName === self::ENTRIES_TAG) {
                 $cookie[self::ENTRIES_TAG] = self::parse($child)['cookies'];
+            }
+
+            if ($child->tagName === self::ACTIVE_PAYMENT_METHOD_TAG) {
+                $cookie[self::ACTIVE_PAYMENT_METHODS_KEY][] = $child->nodeValue;
             }
         }
 

--- a/src/Core/Framework/DependencyInjection/app.php
+++ b/src/Core/Framework/DependencyInjection/app.php
@@ -446,6 +446,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(AppCookieCollectListener::class)
         ->args([
             service('app.repository'),
+            service('payment_method.repository'),
         ])
         ->tag('kernel.event_listener');
 

--- a/tests/integration/Core/Framework/App/Cookie/CookieGroupCollectListenerTest.php
+++ b/tests/integration/Core/Framework/App/Cookie/CookieGroupCollectListenerTest.php
@@ -33,7 +33,31 @@ class CookieGroupCollectListenerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->listener = new AppCookieCollectListener(static::getContainer()->get('app.repository'));
+        $this->listener = new AppCookieCollectListener(
+            static::getContainer()->get('app.repository'),
+            static::getContainer()->get('payment_method.repository'),
+        );
+    }
+
+    public function testItFiltersCookiesOfInactivePaymentMethods(): void
+    {
+        $this->loadAppsFromDir(__DIR__ . '/_fixtures/conditionalCookie');
+
+        $event = new CookieGroupCollectEvent(
+            new CookieGroupCollection(),
+            new Request(),
+            Generator::generateSalesChannelContext()
+        );
+        ($this->listener)($event);
+
+        $firstGroup = $event->cookieGroupCollection->first();
+        static::assertNotNull($firstGroup);
+        $entries = $firstGroup->getEntries();
+        static::assertNotNull($entries);
+        static::assertCount(1, $entries);
+        static::assertNotNull($entries->get('swag-app-always'));
+        static::assertNull($entries->get('swag-app-payment'));
+        static::assertNull($entries->get('swag-app-any-payment'));
     }
 
     public function testSingleCookie(): void

--- a/tests/integration/Core/Framework/App/Cookie/_fixtures/conditionalCookie/manifest.xml
+++ b/tests/integration/Core/Framework/App/Cookie/_fixtures/conditionalCookie/manifest.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd">
+    <meta>
+        <name>SwagApp</name>
+        <label>Swag App Test</label>
+        <label lang="de-DE">Swag App Test</label>
+        <description>Test for App System</description>
+        <description lang="de-DE">Test für das App System</description>
+        <author>shopware AG</author>
+        <copyright>(c) by shopware AG</copyright>
+        <version>1.0.0</version>
+        <icon>icon.png</icon>
+        <license>MIT</license>
+        <privacy>https://test.com/privacy</privacy>
+    </meta>
+    <cookies>
+        <group>
+            <snippet-name>app.cookies.group</snippet-name>
+            <entries>
+                <cookie>
+                    <snippet-name>always.shown</snippet-name>
+                    <cookie>swag-app-always</cookie>
+                </cookie>
+                <cookie>
+                    <snippet-name>payment.bound</snippet-name>
+                    <cookie>swag-app-payment</cookie>
+                    <active-payment-method>myPaymentMethod</active-payment-method>
+                </cookie>
+                <cookie>
+                    <snippet-name>any.payment.bound</snippet-name>
+                    <cookie>swag-app-any-payment</cookie>
+                    <active-payment-method>*</active-payment-method>
+                </cookie>
+            </entries>
+        </group>
+    </cookies>
+</manifest>

--- a/tests/unit/Core/Framework/App/Cookie/AppCookieCollectListenerTest.php
+++ b/tests/unit/Core/Framework/App/Cookie/AppCookieCollectListenerTest.php
@@ -6,6 +6,8 @@ namespace Shopware\Tests\Unit\Core\Framework\App\Cookie;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
 use Shopware\Core\Content\Cookie\Service\CookieProvider;
 use Shopware\Core\Content\Cookie\Struct\CookieEntry;
@@ -46,7 +48,7 @@ class AppCookieCollectListenerTest extends TestCase
                 'snippet_name' => 'swag.analytics.name',
             ],
         ]);
-        $this->createListener($appEntity)->__invoke($event);
+        $this->createListener([$appEntity])->__invoke($event);
 
         $groups = $event->cookieGroupCollection;
         static::assertCount(1, $groups);
@@ -85,7 +87,7 @@ class AppCookieCollectListenerTest extends TestCase
                 'snippet_description' => 'app.cookies.group.description',
             ],
         ]);
-        $this->createListener($appEntity)->__invoke($event);
+        $this->createListener([$appEntity])->__invoke($event);
 
         $groups = $event->cookieGroupCollection;
         static::assertCount(1, $groups);
@@ -142,7 +144,7 @@ class AppCookieCollectListenerTest extends TestCase
                 'snippet_name' => CookieProvider::SNIPPET_NAME_COOKIE_GROUP_REQUIRED,
             ],
         ]);
-        $this->createListener($appEntity)->__invoke($event);
+        $this->createListener([$appEntity])->__invoke($event);
 
         $groups = $event->cookieGroupCollection;
         static::assertCount(1, $groups);
@@ -204,7 +206,7 @@ class AppCookieCollectListenerTest extends TestCase
                 'snippet_name' => 'app.cookie.group.name',
             ],
         ]);
-        $this->createListener($firstAppEntity, $secondAppEntity)->__invoke($event);
+        $this->createListener([$firstAppEntity, $secondAppEntity])->__invoke($event);
 
         $groups = $event->cookieGroupCollection;
         static::assertCount(1, $groups);
@@ -246,6 +248,150 @@ class AppCookieCollectListenerTest extends TestCase
         static::assertEmpty($groups);
     }
 
+    public function testItFiltersEntriesOfInactivePaymentMethods(): void
+    {
+        $event = new CookieGroupCollectEvent(
+            new CookieGroupCollection(),
+            new Request(),
+            Generator::generateSalesChannelContext()
+        );
+
+        $appEntity = $this->createAppEntity(Uuid::randomHex(), [
+            [
+                'entries' => [
+                    [
+                        'cookie' => 'swag-app-something',
+                        'snippet_name' => 'first.something',
+                    ],
+                    [
+                        'cookie' => 'swag-app-payment',
+                        'snippet_name' => 'second.payment',
+                        'active_payment_methods' => ['myPaymentMethod'],
+                    ],
+                ],
+                'snippet_name' => 'app.cookies.group',
+            ],
+        ]);
+        $this->createListener([$appEntity])->__invoke($event);
+
+        $firstGroup = $event->cookieGroupCollection->first();
+        static::assertNotNull($firstGroup);
+        $entries = $firstGroup->getEntries();
+        static::assertNotNull($entries);
+        static::assertCount(1, $entries);
+        static::assertNotNull($entries->get('swag-app-something'));
+        static::assertNull($entries->get('swag-app-payment'));
+    }
+
+    public function testItKeepsEntriesOfActivePaymentMethods(): void
+    {
+        $event = new CookieGroupCollectEvent(
+            new CookieGroupCollection(),
+            new Request(),
+            Generator::generateSalesChannelContext()
+        );
+
+        $appEntity = $this->createAppEntity(Uuid::randomHex(), [
+            [
+                'entries' => [
+                    [
+                        'cookie' => 'swag-app-payment',
+                        'snippet_name' => 'first.payment',
+                        'active_payment_methods' => ['inactivePaymentMethod', 'myPaymentMethod'],
+                    ],
+                ],
+                'snippet_name' => 'app.cookies.group',
+            ],
+        ]);
+        $this->createListener([$appEntity], ['app\\TestApp_myPaymentMethod'])->__invoke($event);
+
+        $firstGroup = $event->cookieGroupCollection->first();
+        static::assertNotNull($firstGroup);
+        $entries = $firstGroup->getEntries();
+        static::assertNotNull($entries);
+        static::assertCount(1, $entries);
+        static::assertNotNull($entries->get('swag-app-payment'));
+    }
+
+    public function testItKeepsWildcardEntriesWhenAnyAppPaymentMethodIsActive(): void
+    {
+        $event = new CookieGroupCollectEvent(
+            new CookieGroupCollection(),
+            new Request(),
+            Generator::generateSalesChannelContext()
+        );
+
+        $appEntity = $this->createAppEntity(Uuid::randomHex(), [
+            [
+                'entries' => [
+                    [
+                        'cookie' => 'swag-app-payment',
+                        'snippet_name' => 'first.payment',
+                        'active_payment_methods' => ['*'],
+                    ],
+                ],
+                'snippet_name' => 'app.cookies.group',
+            ],
+        ]);
+        $this->createListener([$appEntity], ['app\\TestApp_anyOfItsMethods'])->__invoke($event);
+
+        $firstGroup = $event->cookieGroupCollection->first();
+        static::assertNotNull($firstGroup);
+        $entries = $firstGroup->getEntries();
+        static::assertNotNull($entries);
+        static::assertCount(1, $entries);
+        static::assertNotNull($entries->get('swag-app-payment'));
+    }
+
+    public function testItFiltersWildcardEntriesWhenOnlyOtherAppsPaymentMethodsAreActive(): void
+    {
+        $event = new CookieGroupCollectEvent(
+            new CookieGroupCollection(),
+            new Request(),
+            Generator::generateSalesChannelContext()
+        );
+
+        $appEntity = $this->createAppEntity(Uuid::randomHex(), [
+            [
+                'entries' => [
+                    [
+                        'cookie' => 'swag-app-payment',
+                        'snippet_name' => 'first.payment',
+                        'active_payment_methods' => ['*'],
+                    ],
+                ],
+                'snippet_name' => 'app.cookies.group',
+            ],
+        ]);
+        $this->createListener([$appEntity], ['app\\OtherApp_someMethod'])->__invoke($event);
+
+        $firstGroup = $event->cookieGroupCollection->first();
+        static::assertNotNull($firstGroup);
+        $entries = $firstGroup->getEntries();
+        static::assertNotNull($entries);
+        static::assertCount(0, $entries);
+    }
+
+    public function testItFiltersTopLevelCookiesOfInactivePaymentMethods(): void
+    {
+        $event = new CookieGroupCollectEvent(
+            new CookieGroupCollection(),
+            new Request(),
+            Generator::generateSalesChannelContext()
+        );
+
+        $appEntity = $this->createAppEntity(Uuid::randomHex(), [
+            [
+                'cookie' => 'swag-analytics',
+                'snippet_name' => 'swag.analytics.name',
+                'active_payment_methods' => ['myPaymentMethod'],
+            ],
+        ]);
+        $this->createListener([$appEntity])->__invoke($event);
+
+        static::assertEmpty($event->cookieGroupCollection);
+    }
+
     /**
      * @param list<Cookie> $cookies
      */
@@ -254,16 +400,35 @@ class AppCookieCollectListenerTest extends TestCase
         return (new AppEntity())->assign([
             'id' => $appId,
             '_uniqueIdentifier' => $appId,
+            'name' => 'TestApp',
             'cookies' => $cookies,
         ]);
     }
 
-    private function createListener(AppEntity ...$appEntity): AppCookieCollectListener
+    /**
+     * @param list<AppEntity> $appEntities
+     * @param list<string> $activePaymentMethodHandlers
+     */
+    private function createListener(array $appEntities = [], array $activePaymentMethodHandlers = []): AppCookieCollectListener
     {
         $appRepo = new StaticEntityRepository([
-            new AppCollection([...$appEntity]),
+            new AppCollection($appEntities),
         ]);
 
-        return new AppCookieCollectListener($appRepo);
+        $paymentMethods = [];
+        foreach ($activePaymentMethodHandlers as $handlerIdentifier) {
+            $id = Uuid::randomHex();
+            $paymentMethods[] = (new PaymentMethodEntity())->assign([
+                'id' => $id,
+                '_uniqueIdentifier' => $id,
+                'handlerIdentifier' => $handlerIdentifier,
+            ]);
+        }
+
+        $paymentMethodRepo = new StaticEntityRepository([
+            new PaymentMethodCollection($paymentMethods),
+        ]);
+
+        return new AppCookieCollectListener($appRepo, $paymentMethodRepo);
     }
 }

--- a/tests/unit/Core/Framework/App/Cookie/AppCookieCollectListenerTest.php
+++ b/tests/unit/Core/Framework/App/Cookie/AppCookieCollectListenerTest.php
@@ -7,6 +7,7 @@ namespace Shopware\Tests\Unit\Core\Framework\App\Cookie;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Checkout\Payment\PaymentMethodDefinition;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
 use Shopware\Core\Content\Cookie\Service\CookieProvider;
@@ -15,6 +16,7 @@ use Shopware\Core\Content\Cookie\Struct\CookieEntryCollection;
 use Shopware\Core\Content\Cookie\Struct\CookieGroup;
 use Shopware\Core\Content\Cookie\Struct\CookieGroupCollection;
 use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppDefinition;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Cookie\AppCookieCollectListener;
 use Shopware\Core\Framework\Log\Package;
@@ -413,7 +415,7 @@ class AppCookieCollectListenerTest extends TestCase
     {
         $appRepo = new StaticEntityRepository([
             new AppCollection($appEntities),
-        ]);
+        ], new AppDefinition());
 
         $paymentMethods = [];
         foreach ($activePaymentMethodHandlers as $handlerIdentifier) {
@@ -427,7 +429,7 @@ class AppCookieCollectListenerTest extends TestCase
 
         $paymentMethodRepo = new StaticEntityRepository([
             new PaymentMethodCollection($paymentMethods),
-        ]);
+        ], new PaymentMethodDefinition());
 
         return new AppCookieCollectListener($appRepo, $paymentMethodRepo);
     }

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Cookie/CookiesTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Cookie/CookiesTest.php
@@ -20,6 +20,19 @@ class CookiesTest extends TestCase
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../../_fixtures/test/manifest.xml');
 
         static::assertNotNull($manifest->getCookies());
-        static::assertCount(2, $manifest->getCookies()->getCookies());
+        $cookies = $manifest->getCookies()->getCookies();
+        static::assertCount(2, $cookies);
+
+        static::assertArrayNotHasKey('active_payment_methods', $cookies[0]);
+
+        static::assertArrayHasKey('entries', $cookies[1]);
+        $entries = $cookies[1]['entries'];
+        static::assertIsArray($entries);
+        static::assertCount(2, $entries);
+        static::assertArrayNotHasKey('active_payment_methods', $entries[0]);
+        static::assertSame(
+            ['myPaymentMethod', 'myOtherPaymentMethod'],
+            $entries[1]['active_payment_methods'] ?? null
+        );
     }
 }

--- a/tests/unit/Core/Framework/App/Manifest/_fixtures/test/manifest.xml
+++ b/tests/unit/Core/Framework/App/Manifest/_fixtures/test/manifest.xml
@@ -121,6 +121,8 @@ Folgende Nutzerdaten werden auf Servern der shopware AG verarbeitet:
                 <cookie>
                     <snippet-name>Lorem ipsum</snippet-name>
                     <cookie>swag.app.lorem-ipsum</cookie>
+                    <active-payment-method>myPaymentMethod</active-payment-method>
+                    <active-payment-method>myOtherPaymentMethod</active-payment-method>
                 </cookie>
             </entries>
         </group>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Cookies declared in an app manifest were always shown in the cookie consent manager, on every sales channel

### 2. What does this change do, exactly?
A cookie can now reference payment methods of the app via the repeatable <active-payment-method> element and is only added when at least one referenced method is active in the current sales channel. This gives apps the equivalent of what plugins can do with CookieGroupCollectEvent


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- close #18739
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
