### PR TITLE
feat(admin): add modal has iframe dialog content style hidden overflow

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-modals-renderer/sw-modals-renderer.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-modals-renderer/sw-modals-renderer.scss
@@ -1,4 +1,8 @@
 .sw-modals-renderer__modal.has-iframe {
+    .sw-modal__dialog {
+        overflow: hidden;
+    }
+
     .sw-modal__body.has--no-footer {
         border-radius: 0 0 var(--border-radius-card) var(--border-radius-card);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
In this PR, its much simply add the style to `sw-modals-renderer` which `has-iframe` to  prevent the iframe to overflow the dialog bounds.

A bit explanation for the previous PR I tried to using new prop in order not to violate all the modal content but youre right the iframe takes the effect only.

<img width="1067" height="774" alt="image" src="https://github.com/user-attachments/assets/dcd5be8c-79ef-4eb4-a18f-58c93e41d630" />

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
