### PR TITLE
fix: prevent popovers from overlapping top bar

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/index.ts
@@ -11,6 +11,12 @@ export default Shopware.Component.wrapComponentConfig({
     template,
 
     props: {
+        autoUpdateOptions: {
+            type: Object,
+            required: false,
+            default: () => ({}),
+        },
+
         isOpened: {
             type: Boolean,
             required: false,
@@ -50,6 +56,13 @@ export default Shopware.Component.wrapComponentConfig({
 
             // Fallback to deprecated prop
             return this.resizeWidth;
+        },
+
+        computedAutoUpdateOptions() {
+            return {
+                ancestorScroll: false,
+                ...this.autoUpdateOptions,
+            };
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.html.twig
@@ -6,6 +6,7 @@
     v-bind="$attrs"
     :is-opened="isOpened"
     :match-reference-width="computedMatchReferenceWidth"
+    :auto-update-options="computedAutoUpdateOptions"
 >
     <template
         v-for="(index, name) in getSlots()"

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.spec.js
@@ -9,7 +9,11 @@ async function createWrapper(additionalOptions = {}) {
         global: {
             stubs: {
                 'sw-popover-deprecated': true,
-                'mt-floating-ui': true,
+                'mt-floating-ui': {
+                    name: 'mt-floating-ui',
+                    props: ['autoUpdateOptions'],
+                    template: '<div><slot /></div>',
+                },
             },
         },
         props: {},
@@ -32,7 +36,7 @@ describe('src/app/component/base/sw-popover', () => {
 
         const wrapper = await createWrapper();
 
-        expect(wrapper.html()).toContain('mt-floating-ui');
+        expect(wrapper.findComponent({ name: 'mt-floating-ui' }).exists()).toBe(true);
     });
 
     it('should pass the "resizeWidth" prop to the "matchReferenceWidth" property in mt-floating-ui with true', async () => {
@@ -159,5 +163,48 @@ describe('src/app/component/base/sw-popover', () => {
 
         const deprecatedPopover = wrapper.findComponent({ name: 'sw-popover-deprecated' });
         expect(deprecatedPopover.attributes('resize-width')).toBe('true');
+    });
+
+    it('should use the legacy auto-update options by default', async () => {
+        global.activeFeatureFlags = ['V6_8_0_0'];
+
+        const wrapper = await createWrapper();
+
+        expect(wrapper.findComponent({ name: 'mt-floating-ui' }).props('autoUpdateOptions')).toEqual({
+            ancestorScroll: false,
+        });
+    });
+
+    it('should merge custom auto-update options with the legacy default', async () => {
+        global.activeFeatureFlags = ['V6_8_0_0'];
+
+        const wrapper = await createWrapper({
+            attrs: {
+                'auto-update-options': {
+                    elementResize: false,
+                },
+            },
+        });
+
+        expect(wrapper.findComponent({ name: 'mt-floating-ui' }).props('autoUpdateOptions')).toEqual({
+            ancestorScroll: false,
+            elementResize: false,
+        });
+    });
+
+    it('should allow custom auto-update options to override the legacy default', async () => {
+        global.activeFeatureFlags = ['V6_8_0_0'];
+
+        const wrapper = await createWrapper({
+            attrs: {
+                autoUpdateOptions: {
+                    ancestorScroll: true,
+                },
+            },
+        });
+
+        expect(wrapper.findComponent({ name: 'mt-floating-ui' }).props('autoUpdateOptions')).toEqual({
+            ancestorScroll: true,
+        });
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

When an overflow ancestor is scrolled, `mt-floating-ui` updates the popover position. Its configured z-index can then place the popover above the Administration top bar.

### 2. What does this change do, exactly?

Disables position updates on overflow-ancestor scrolling by default, matching legacy behavior. This is a targeted fix; updating the z-index handling across all affected components would be a larger change. Callers can still extend or override the auto-update options.

**Before:**

https://github.com/user-attachments/assets/03f452ed-c5c5-40bf-9682-7da8b4a51627

**After:**

https://github.com/user-attachments/assets/c56e6328-b595-48d7-8d70-5ef604273ef4

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable the Meteor popover by setting `V6_8_0_0=1`.
2. Open a popover inside an overflow container.
3. Scroll the overflow ancestor.
4. Observe the popover appearing above the Administration top bar.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #18169

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
