### PR TITLE
fix: memoize plugin locale translation lookups

### DIFF
--- a/src/Core/System/DependencyInjection/snippet.php
+++ b/src/Core/System/DependencyInjection/snippet.php
@@ -131,7 +131,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('shopware.translation.client'),
             service(TranslationConfig::class),
             service('event_dispatcher'),
-        ]);
+        ])
+        ->tag('kernel.reset', ['method' => 'reset']);
 
     $services->set(TranslationMetadataStore::class)
         ->args([

--- a/src/Core/System/DependencyInjection/snippet.php
+++ b/src/Core/System/DependencyInjection/snippet.php
@@ -131,8 +131,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service('shopware.translation.client'),
             service(TranslationConfig::class),
             service('event_dispatcher'),
-        ])
-        ->tag('kernel.reset', ['method' => 'reset']);
+        ]);
 
     $services->set(TranslationMetadataStore::class)
         ->args([

--- a/src/Core/System/Snippet/Service/TranslationLoader.php
+++ b/src/Core/System/Snippet/Service/TranslationLoader.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Locale\LocaleCollection;
@@ -25,12 +26,13 @@ use Shopware\Core\System\Snippet\SnippetPatterns;
 use Shopware\Core\System\Snippet\Struct\TranslationConfig;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Path;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @internal
  */
 #[Package('discovery')]
-class TranslationLoader extends AbstractTranslationLoader
+class TranslationLoader extends AbstractTranslationLoader implements ResetInterface
 {
     private const PLATFORM_BUNDLES = [
         'Administration' => 'administration.json',
@@ -42,6 +44,11 @@ class TranslationLoader extends AbstractTranslationLoader
         'Storefront',
         'Administration',
     ];
+
+    /**
+     * @var ArrayStruct<list<string>>|null
+     */
+    private ?ArrayStruct $existingPluginLocaleTranslations = null;
 
     /**
      * @param EntityRepository<LanguageCollection> $languageRepository
@@ -75,6 +82,9 @@ class TranslationLoader extends AbstractTranslationLoader
         $this->fetchPlatformSnippets($locale);
         $this->fetchPluginSnippets($locale);
 
+        // new plugin translation directories may have been written, invalidate the memoized lookup
+        $this->reset();
+
         $this->createLanguage($language, $context, $activate);
         $this->createSnippetSet($language, $context);
 
@@ -83,28 +93,30 @@ class TranslationLoader extends AbstractTranslationLoader
 
     public function pluginTranslationExists(Plugin $plugin): bool
     {
+        $this->memoizePluginLocaleTranslations();
+
         $name = $this->config->getMappedPluginName($plugin);
-        $localesBasePath = $this->getLocalesBasePath();
 
-        if (!$this->translationWriter->directoryExists($localesBasePath)) {
-            return false;
-        }
-
-        foreach ($this->translationWriter->listContents($localesBasePath, Filesystem::LIST_DEEP) as $fsNode) {
-            if ($fsNode->isDir() && str_ends_with($fsNode->path(), 'Plugins/' . $name)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->existingPluginLocaleTranslations?->has($name) === true;
     }
 
     public function pluginTranslationExistsForLocale(Plugin $plugin, string $locale): bool
     {
-        $name = $this->config->getMappedPluginName($plugin);
-        $pluginPath = Path::join($this->getLocalePath($locale), 'Plugins', $name);
+        $this->memoizePluginLocaleTranslations();
 
-        return $this->translationWriter->directoryExists($pluginPath);
+        $name = $this->config->getMappedPluginName($plugin);
+        $localesByPlugin = $this->existingPluginLocaleTranslations?->get($name);
+
+        if (!\is_array($localesByPlugin)) {
+            return false;
+        }
+
+        return \in_array(\strtolower($locale), $localesByPlugin, true);
+    }
+
+    public function reset(): void
+    {
+        $this->existingPluginLocaleTranslations = null;
     }
 
     public function getLocalesBasePath(): string
@@ -123,6 +135,30 @@ class TranslationLoader extends AbstractTranslationLoader
         }
 
         return Path::join(static::TRANSLATION_DIR, static::TRANSLATION_LOCALE_SUB_DIR, $locale);
+    }
+
+    private function memoizePluginLocaleTranslations(): void
+    {
+        if ($this->existingPluginLocaleTranslations !== null) {
+            return;
+        }
+
+        $localesBasePath = $this->getLocalesBasePath();
+        /** @var ArrayStruct<list<string>> $pluginLocales */
+        $pluginLocales = new ArrayStruct();
+
+        foreach ($this->translationWriter->listContents($localesBasePath, Filesystem::LIST_DEEP) as $fsNode) {
+            if (\preg_match('#(?P<locale>[^/]+)/Plugins/(?P<plugin>[^/]+)#', $fsNode->path(), $matches) !== 1) {
+                continue;
+            }
+
+            $locales = $pluginLocales->get($matches['plugin']) ?? [];
+            $locales[] = \strtolower($matches['locale']);
+
+            $pluginLocales->set($matches['plugin'], \array_unique($locales));
+        }
+
+        $this->existingPluginLocaleTranslations = $pluginLocales;
     }
 
     private function fetchPluginSnippets(string $locale): void

--- a/tests/unit/Core/System/Snippet/Service/TranslationLoaderTest.php
+++ b/tests/unit/Core/System/Snippet/Service/TranslationLoaderTest.php
@@ -249,13 +249,12 @@ class TranslationLoaderTest extends TestCase
     {
         $loader = $this->getTranslationLoader();
 
-        $noLocaleBasePathPlugin = new TestPlugin(true, '');
-        $noLocaleBasePathPlugin->setName('NoLocaleBasePathExists');
-        static::assertFalse($loader->pluginTranslationExists($noLocaleBasePathPlugin));
-
         $existingPlugin = new TestPlugin(true, '');
         $existingPlugin->setName('SwagPublisher');
         $this->flysystem->createDirectory($loader->getLocalePath('de-DE') . '/Plugins/SwagPublisher');
+
+        $noLocaleBasePathPlugin = new TestPlugin(true, '');
+        $noLocaleBasePathPlugin->setName('NoLocaleBasePathExists');
 
         static::assertTrue($loader->pluginTranslationExists($existingPlugin));
         static::assertFalse($loader->pluginTranslationExists($noLocaleBasePathPlugin));
@@ -345,8 +344,51 @@ class TranslationLoaderTest extends TestCase
         $this->flysystem->createDirectory($loader->getLocalePath('de-DE') . '/Plugins/SwagPaypal');
         static::assertFalse($loader->pluginTranslationExistsForLocale($mappedNamePlugin, 'de-DE'));
 
+        // the negative result is memoized, so the loader must be reset to observe the newly installed translation
         $this->flysystem->createDirectory($loader->getLocalePath('de-DE') . '/Plugins/MappedName');
+        $loader->reset();
         static::assertTrue($loader->pluginTranslationExistsForLocale($mappedNamePlugin, 'de-DE'));
+    }
+
+    public function testPluginTranslationExistsForLocaleMemoizesPositiveResult(): void
+    {
+        $loader = $this->getTranslationLoader();
+
+        $existingPlugin = new TestPlugin(true, '');
+        $existingPlugin->setName('SwagPublisher');
+
+        $pluginPath = $loader->getLocalePath('de-DE') . '/Plugins/SwagPublisher';
+        $this->flysystem->createDirectory($pluginPath);
+
+        static::assertTrue($loader->pluginTranslationExistsForLocale($existingPlugin, 'de-DE'));
+
+        // the directory is removed on the filesystem, but the memoized result must be reused without a new remote check
+        $this->flysystem->deleteDirectory($pluginPath);
+        static::assertTrue($loader->pluginTranslationExistsForLocale($existingPlugin, 'de-DE'));
+
+        // reset() drops the memoized lookup so the next call reflects the current filesystem state again
+        $loader->reset();
+        static::assertFalse($loader->pluginTranslationExistsForLocale($existingPlugin, 'de-DE'));
+    }
+
+    public function testPluginTranslationExistsForLocaleMemoizesNegativeResult(): void
+    {
+        $loader = $this->getTranslationLoader();
+
+        $existingPlugin = new TestPlugin(true, '');
+        $existingPlugin->setName('SwagPublisher');
+
+        $pluginPath = $loader->getLocalePath('de-DE') . '/Plugins/SwagPublisher';
+
+        static::assertFalse($loader->pluginTranslationExistsForLocale($existingPlugin, 'de-DE'));
+
+        // the directory is created on the filesystem, but the memoized negative result must be reused without a new check
+        $this->flysystem->createDirectory($pluginPath);
+        static::assertFalse($loader->pluginTranslationExistsForLocale($existingPlugin, 'de-DE'));
+
+        // reset() drops the memoized lookup so the next call reflects the current filesystem state again
+        $loader->reset();
+        static::assertTrue($loader->pluginTranslationExistsForLocale($existingPlugin, 'de-DE'));
     }
 
     public function testLoadCreatesLanguageWithActiveFalseWhenSkipped(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

With `shopware.filesystem.private` backed by S3 (or any high-latency object storage), building the snippet file collection spent multiple seconds purely on remote existence checks for plugin translations (~2.5s reported by a customer).

`SnippetFileLoader::loadShippedSnippets()` iterates every shipped plugin snippet file and, for each one, calls `TranslationLoader::pluginTranslationExistsForLocale()`, which issues a Flysystem `directoryExists()` on `shopware.filesystem.private`. There was no memoization, so the same `(plugin, locale)` pair was checked once per snippet file, turning `O(plugins)` into `O(plugin snippet files)` (plugins × locales × files) remote round-trips. On S3 each check is a network call, so shops with many plugins and multi-locale shipped snippets stalled for seconds on every cold collection build (which happens after every deploy, theme compile, `snippet.written`, or Redis eviction, not just on first startup).

  ### 2. What does this change do, exactly?

 `TranslationLoader` now builds the plugin/locale translation lookup **once per request** from a single deep listing of the private filesystem and answers all existence checks from memory:

- Added an in-process memoization (`ArrayStruct` keyed by mapped plugin name → set of locales) populated by one `listContents(..., LIST_DEEP)` over the translations base path. `pluginTranslationExistsForLocale()` and `pluginTranslationExists()` resolve against this map instead of issuing a `directoryExists()` per snippet file.
- `TranslationLoader` implements `ResetInterface`; the memoization is reset in `reset()` and after `load()` writes new translation directories, so a stale lookup can't survive a translation install.

This collapses the remote access for a full collection build from one call per plugin snippet file to a single filesystem listing. `TranslationLoader` remains `@internal`; there is no public API, DAL, or template change, so no release/upgrade notes are required.

### 3. Describe each step to reproduce the issue or behaviour.

  1. Configure `shopware.filesystem.private` to use S3 (or another remote adapter with noticeable latency).
  2. Install several plugins that ship multi-locale files under `Resources/snippet/` (and/or install multiple locales via `translation:install`).
  3. Clear caches so `SnippetFileCollection` is rebuilt (full cache clear / cold app).
  4. Trigger anything that builds the snippet file collection (storefront request after cold start, admin snippet module, etc.).
  5. Profile: before this change, many sequential `directoryExists` (S3 LIST/HEAD) calls fire from `pluginTranslationExistsForLocale` during `loadShippedSnippets()`; after it, existence checks are served from a single in-process listing.

### 4. Please link to the relevant issues (if any).

  closes #18726

### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation and agent skills according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them