### PR TITLE
chore: guard deprecated EntitySearchResult usage with the upstream rector rule

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Frosh\Rector\Rule\v68\EntitySearchResultGetEntitiesRector;
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
@@ -23,12 +24,19 @@ return RectorConfig::configure()
         '**/vendor/*',
         '**/node_modules/*',
         '**/Resources/*',
+
+        // BC test deliberately covering the deprecated delegations until their removal
+        EntitySearchResultGetEntitiesRector::class => [
+            __DIR__ . '/tests/unit/Core/Framework/DataAbstractionLayer/Search/EntitySearchResultTest.php',
+        ],
     ])
     ->withCache(
         cacheDirectory: __DIR__ . '/var/cache/rector',
         cacheClass: FileCacheStorage::class,
     )
     ->withRules([
+        // Guards against the deprecated collection surface of EntitySearchResult (see #18655)
+        EntitySearchResultGetEntitiesRector::class,
         ClassConstantToSelfClassRector::class,
         DisallowedEmptyRuleFixerRector::class,
         CountArrayToEmptyArrayComparisonRector::class,

--- a/vendor-bin/rector/composer.json
+++ b/vendor-bin/rector/composer.json
@@ -1,5 +1,6 @@
 {
     "require-dev": {
+        "frosh/shopware-rector": "^0.5.10",
         "rector/rector": "^2.3.6"
     },
     "sort-packages": true


### PR DESCRIPTION
### 1. Why is this change necessary?

The EntitySearchResult collection surface is deprecated and all usages were swept; without a guard, new deprecated usages creep back in between majors.

### 2. What does this change do, exactly?

- Adds `frosh/shopware-rector` `^0.5.10` to the rector vendor-bin harness (first release shipping `EntitySearchResultGetEntitiesRector`).
- Registers the rule in `rector.php`.
- Scopes a skip for `tests/unit/.../EntitySearchResultTest.php`, the BC test that deliberately covers the deprecated delegations until their removal.

A full `rector process --dry-run` over `src/` and `tests/` reports no other findings, confirming the sweep is complete and the rule now acts purely as a guard.

### 3. Describe each step to reproduce the issue or behaviour.

`composer rector` (dry-run) flags any reintroduced usage of the deprecated EntitySearchResult collection methods and suggests the `getEntities()` rewrite.

### 4. Please link to the relevant issues (if any).

- closes #18655

### 5. Checklist

- [x] I have written tests and verified that they fail without my change (not applicable: static-analysis tooling; the rule ships with its own test suite upstream)
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
