### PR TITLE
fix(inventory): enforce ACL on SEO admin action endpoints

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -4,6 +4,16 @@
 
 ## API
 
+### SEO admin action endpoints now require ACL privileges
+
+Four admin action endpoints that previously only required authentication now enforce ACL privileges. Requests with tokens lacking the privilege receive a `403` with `FRAMEWORK__MISSING_PRIVILEGE_ERROR`:
+
+* `PATCH /api/_action/seo-url/canonical` requires `seo_url:update`.
+* `POST /api/_action/seo-url/create-custom-url` requires `seo_url:create`.
+* `POST /api/_action/seo-url-template/context` and `GET /api/_action/seo-url-template/default/{routeName}` require `seo_url_template:read`.
+
+Administration users are not affected: `seo_url:update` is now part of the "Products editor", "Categories editor", and "Landing pages editor" permissions in the role editor — these are the roles whose users write canonical URLs when saving — and a migration grants it to existing roles that already hold one of those permissions. The template privileges are already part of the system configuration permission that the SEO settings page requires. Integrations and API clients with manually assigned privilege lists must add the respective privilege to their ACL role.
+
 ### Increment and queue-stats admin endpoints now require ACL privileges
 
 Seven admin endpoints that previously only required authentication now enforce ACL privileges. Requests with tokens lacking the privilege receive a `403` with `FRAMEWORK__MISSING_PRIVILEGE_ERROR`:

--- a/src/Administration/Resources/app/administration/src/module/sw-category/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/acl/index.js
@@ -41,6 +41,7 @@ Shopware.Service('privileges')
                     'tag:create',
                     'category_tag:create',
                     'category_tag:delete',
+                    'seo_url:update',
                 ],
                 dependencies: [
                     'category.viewer',
@@ -99,6 +100,7 @@ Shopware.Service('privileges')
                     'landing_page_tag:delete',
                     'landing_page_sales_channel:create',
                     'landing_page_sales_channel:delete',
+                    'seo_url:update',
                 ],
                 dependencies: [
                     'category.viewer',

--- a/src/Administration/Resources/app/administration/src/module/sw-product/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/acl/index.js
@@ -104,6 +104,7 @@ Shopware.Service('privileges').addPrivilegeMappingEntry({
                 'product_feature_set:delete',
                 'user_config:create',
                 'user_config:update',
+                'seo_url:update',
             ],
             dependencies: [
                 'product.viewer',

--- a/src/Core/Content/Seo/Api/SeoActionController.php
+++ b/src/Core/Content/Seo/Api/SeoActionController.php
@@ -109,7 +109,12 @@ class SeoActionController extends AbstractController
         return new JsonResponse($preview);
     }
 
-    #[Route(path: '/api/_action/seo-url-template/context', name: 'api.seo-url-template.context', methods: [Request::METHOD_POST])]
+    #[Route(
+        path: '/api/_action/seo-url-template/context',
+        name: 'api.seo-url-template.context',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['seo_url_template:read']],
+        methods: [Request::METHOD_POST]
+    )]
     public function getSeoUrlContext(RequestDataBag $data, Context $context): JsonResponse
     {
         $routeName = $data->get('routeName');
@@ -142,7 +147,12 @@ class SeoActionController extends AbstractController
         return new JsonResponse($mapping->getSeoPathInfoContext());
     }
 
-    #[Route(path: '/api/_action/seo-url/canonical', name: 'api.seo-url.canonical', methods: [Request::METHOD_PATCH])]
+    #[Route(
+        path: '/api/_action/seo-url/canonical',
+        name: 'api.seo-url.canonical',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['seo_url:update']],
+        methods: [Request::METHOD_PATCH]
+    )]
     public function updateCanonicalUrl(RequestDataBag $seoUrl, Context $context): Response
     {
         if (!$seoUrl->has('routeName')) {
@@ -187,7 +197,12 @@ class SeoActionController extends AbstractController
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/api/_action/seo-url/create-custom-url', name: 'api.seo-url.create', methods: [Request::METHOD_POST])]
+    #[Route(
+        path: '/api/_action/seo-url/create-custom-url',
+        name: 'api.seo-url.create',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['seo_url:create']],
+        methods: [Request::METHOD_POST]
+    )]
     public function createCustomSeoUrls(RequestDataBag $dataBag, Context $context): Response
     {
         /** @var ParameterBag $dataBag */
@@ -244,7 +259,12 @@ class SeoActionController extends AbstractController
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/api/_action/seo-url-template/default/{routeName}', name: 'api.seo-url-template.default', methods: [Request::METHOD_GET])]
+    #[Route(
+        path: '/api/_action/seo-url-template/default/{routeName}',
+        name: 'api.seo-url-template.default',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['seo_url_template:read']],
+        methods: [Request::METHOD_GET]
+    )]
     public function getDefaultSeoTemplate(string $routeName, Context $context): JsonResponse
     {
         $seoUrlRoute = $this->seoUrlRouteRegistry->findByRouteName($routeName);

--- a/src/Core/Migration/V6_7/Migration1785334458AddSeoUrlUpdateAclPrivilege.php
+++ b/src/Core/Migration/V6_7/Migration1785334458AddSeoUrlUpdateAclPrivilege.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class Migration1785334458AddSeoUrlUpdateAclPrivilege extends MigrationStep
+{
+    final public const NEW_PRIVILEGES = [
+        'product.editor' => [
+            'seo_url:update',
+        ],
+        'category.editor' => [
+            'seo_url:update',
+        ],
+        'landing_page.editor' => [
+            'seo_url:update',
+        ],
+    ];
+
+    public function getCreationTimestamp(): int
+    {
+        return 1785334458;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addAdditionalPrivileges($connection, self::NEW_PRIVILEGES);
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1785334458AddSeoUrlUpdateAclPrivilegeTest.php
+++ b/tests/migration/Core/V6_7/Migration1785334458AddSeoUrlUpdateAclPrivilegeTest.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1785334458AddSeoUrlUpdateAclPrivilege;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(Migration1785334458AddSeoUrlUpdateAclPrivilege::class)]
+class Migration1785334458AddSeoUrlUpdateAclPrivilegeTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private Connection $connection;
+
+    private Migration1785334458AddSeoUrlUpdateAclPrivilege $migration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = KernelLifecycleManager::getConnection();
+        $this->migration = new Migration1785334458AddSeoUrlUpdateAclPrivilege();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1785334458, $this->migration->getCreationTimestamp());
+    }
+
+    #[DataProvider('editorRoleProvider')]
+    public function testAddsSeoUrlUpdateToEditorRoles(string $editorRole): void
+    {
+        $roleId = $this->createRole([$editorRole]);
+
+        // run twice to prove idempotency
+        $this->migration->update($this->connection);
+        $this->migration->update($this->connection);
+
+        $privileges = $this->fetchPrivileges($roleId);
+
+        static::assertContains($editorRole, $privileges);
+        static::assertContains('seo_url:update', $privileges);
+        static::assertCount(1, \array_keys($privileges, 'seo_url:update', true));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function editorRoleProvider(): \Generator
+    {
+        yield 'product editors save canonical urls' => ['product.editor'];
+        yield 'category editors save canonical urls' => ['category.editor'];
+        yield 'landing page editors save canonical urls' => ['landing_page.editor'];
+    }
+
+    public function testUnrelatedRolesAreNotUpdated(): void
+    {
+        $roleId = $this->createRole(['customer.viewer']);
+        $before = $this->connection->fetchAssociative('SELECT * FROM `acl_role` WHERE id = :id', ['id' => $roleId]);
+
+        $this->migration->update($this->connection);
+
+        $after = $this->connection->fetchAssociative('SELECT * FROM `acl_role` WHERE id = :id', ['id' => $roleId]);
+
+        static::assertSame($before, $after);
+    }
+
+    /**
+     * @param list<string> $privileges
+     */
+    private function createRole(array $privileges): string
+    {
+        $roleId = Uuid::randomBytes();
+
+        $this->connection->insert('acl_role', [
+            'id' => $roleId,
+            'name' => 'test seo url acl migration',
+            'privileges' => \json_encode($privileges, \JSON_THROW_ON_ERROR),
+            'created_at' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        return $roleId;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fetchPrivileges(string $roleId): array
+    {
+        $privileges = $this->connection->fetchOne(
+            'SELECT `privileges` FROM `acl_role` WHERE id = :id',
+            ['id' => $roleId]
+        );
+
+        static::assertIsString($privileges);
+
+        $decodedPrivileges = \json_decode($privileges, true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertIsArray($decodedPrivileges);
+        static::assertTrue(\array_is_list($decodedPrivileges));
+        foreach ($decodedPrivileges as $decodedPrivilege) {
+            static::assertIsString($decodedPrivilege);
+        }
+
+        /** @var list<string> $decodedPrivileges */
+        return $decodedPrivileges;
+    }
+}

--- a/tests/unit/Core/Content/Seo/Api/SeoActionControllerTest.php
+++ b/tests/unit/Core/Content/Seo/Api/SeoActionControllerTest.php
@@ -42,7 +42,6 @@ class SeoActionControllerTest extends TestCase
     /**
      * @param list<string> $expectedPrivileges
      */
-    #[TestDox('Route $routeName is guarded by the $expectedPrivileges ACL privilege')]
     #[DataProvider('aclProtectedSeoUrlRouteProvider')]
     public function testRouteRequiresSeoUrlPrivilege(string $routeName, array $expectedPrivileges): void
     {

--- a/tests/unit/Core/Content/Seo/Api/SeoActionControllerTest.php
+++ b/tests/unit/Core/Content/Seo/Api/SeoActionControllerTest.php
@@ -38,4 +38,31 @@ class SeoActionControllerTest extends TestCase
         yield 'validate' => ['api.seo-url-template.validate'];
         yield 'preview' => ['api.seo-url-template.preview'];
     }
+
+    /**
+     * @param list<string> $expectedPrivileges
+     */
+    #[TestDox('Route $routeName is guarded by the $expectedPrivileges ACL privilege')]
+    #[DataProvider('aclProtectedSeoUrlRouteProvider')]
+    public function testRouteRequiresSeoUrlPrivilege(string $routeName, array $expectedPrivileges): void
+    {
+        $route = (new AttributeRouteControllerLoader())->load(SeoActionController::class)->get($routeName);
+
+        static::assertNotNull(
+            $route,
+            \sprintf('Route "%s" is not defined on %s', $routeName, SeoActionController::class)
+        );
+        static::assertSame($expectedPrivileges, $route->getDefault(PlatformRequest::ATTRIBUTE_ACL));
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: list<string>}>
+     */
+    public static function aclProtectedSeoUrlRouteProvider(): \Generator
+    {
+        yield 'updating a canonical url requires seo url write access' => ['api.seo-url.canonical', ['seo_url:update']];
+        yield 'creating custom urls requires seo url create access' => ['api.seo-url.create', ['seo_url:create']];
+        yield 'reading the template context requires template read access' => ['api.seo-url-template.context', ['seo_url_template:read']];
+        yield 'reading the default template requires template read access' => ['api.seo-url-template.default', ['seo_url_template:read']];
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Four SEO admin action endpoints require authentication but declare no _acl privilege, so any authenticated token — including restricted users and integrations without any relevant privilege — can overwrite canonical storefront URLs, create custom SEO URLs, and read SEO template data.

### 2. What does this change do, exactly?
Gates `seo-url/canonical` on `seo_url:update`, `seo-url/create-custom-url` on `seo_url:create`, and `seo-url-template/context` + `seo-url-template/default/{routeName}` on `seo_url_template:read` — all existing entity privileges. `seo_url:update` is bundled into the "Products editor", "Categories editor", and "Landing pages editor" permissions (those users write canonical URLs on save) and a migration grants it to existing roles holding those permissions, so no admin user loses access; the template privileges are already part of the system configuration permission the SEO settings page requires.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a non-admin user or integration with only `product:read` and fetch an admin API token for it.
2. Call `PATCH /api/_action/seo-url/canonical` (or any of the other three routes) with that token.
3. Before: the request succeeds.
4. After: `403` with `FRAMEWORK__MISSING_PRIVILEGE_ERROR`

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
