### PR TITLE
fix(storefront): align checkout finish line items

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_line-item.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_line-item.scss
@@ -226,7 +226,7 @@ $infoItemRemoveMdSpace: 1;
     }
 }
 
-.line-item.is-order {
+.order-detail-content-list > .line-item.is-order {
     margin-left: 20px;
     margin-right: 20px;
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Checkout finish line items became indented after #18294 started rendering them in `order` display mode to preserve the completed order's currency. That mode also activated a legacy 20px margin which was originally intended for line items in the account order detail list.

### 2. What does this change do, exactly?

It scopes the legacy order-line-item margin to direct children of the account order detail list. This restores alignment between the product table header and rows on the checkout finish page while preserving the account order spacing and the order-currency behavior introduced by #18294.

### 3. Describe each step to reproduce the issue or behaviour.

1. Log into the storefront and add a product to the cart.
2. Proceed through checkout and submit the order.
3. On the checkout finish page, compare the product table row with its header.
4. Without this change, every line-item row is indented by 20px on both sides.

### 4. Please link to the relevant issues (if any).

Closes #18786

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them