### PR TITLE
fix: wrong heading hierarchy with offcanvas listing filter headline

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
@@ -1,9 +1,9 @@
 {% block component_filter_panel %}
     {% block component_filter_panel_header %}
         <div class="filter-panel-offcanvas-header">
-            <h2 data-id="off-canvas-headline" class="filter-panel-offcanvas-only filter-panel-offcanvas-title">
+            <span data-id="off-canvas-headline" class="filter-panel-offcanvas-only filter-panel-offcanvas-title">
                 {{ 'listing.filterTitleText'|trans }}
-            </h2>
+            </span>
 
             <button type="button" class="btn-close filter-panel-offcanvas-only filter-panel-offcanvas-close js-offcanvas-close" aria-label="{{ 'listing.filterClose'|trans|striptags }}">
             </button>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Having a content section above a product listing with a heading structure (h1-h6), the heading hierarchy is wrong because the "Filter products" offcanvas headline (h2) is recognized before the actual h1 page title from SEO tools.

### 2. What does this change do, exactly?
Change the offcanvas headline from h2 to span element. There is no style change and it should not be necessary to be a h2.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a content section above product listing with filters containing heading structure (h1-h6)
- Check the heading structure with a tool like https://racoons.ai/tools/heading-structure-checker
- The filter offcanvas heading is shown before the content heading structure

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
