### PR TITLE
docs: document release note formatting and normalize heading spacing

### DIFF
--- a/.agents/skills/shopware-release-docs/SKILL.md
+++ b/.agents/skills/shopware-release-docs/SKILL.md
@@ -28,4 +28,14 @@ Write into the following files, but only if the decision above applies:
   Describe the concrete before and after, and write in past tense, as developers read this only after the next major release.
 - Public REST/Admin/Store API route additions or changes: add or update the matching OpenAPI JSON schema under `src/Core/Framework/Api/ApiDefinition/Generator/Schema/<AdminApi|StoreApi>/paths`.
 
+## What To Write
+
 Write from the outside user's perspective: what changed, who is affected, and what they should do.
+
+State the change and its impact, not the reasoning behind it, the internals of how it works, or the history of the problem. Link the issue or upstream report instead, so readers who want that context can follow it.
+
+## Formatting
+
+- Put a blank line before and after every heading, and between paragraphs.
+- Put the entry under the matching category heading of the upcoming version section, and add that heading if it is missing.
+- Keep code snippets to the shortest form a developer can copy.

--- a/.agents/skills/shopware-release-docs/SKILL.md
+++ b/.agents/skills/shopware-release-docs/SKILL.md
@@ -32,7 +32,7 @@ Write into the following files, but only if the decision above applies:
 
 Write from the outside user's perspective: what changed, who is affected, and what they should do.
 
-State the change and its impact, not the reasoning behind it, the internals of how it works, or the history of the problem. Link the issue or upstream report instead, so readers who want that context can follow it.
+State the change and its impact, not the reasoning behind it, the internals of how it works, or the history of the problem.
 
 ## Formatting
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -12,14 +12,17 @@ Seven admin endpoints that previously only required authentication now enforce A
 * `GET /api/_info/queue.json` and `GET /api/_info/message-stats.json` require the existing `message_queue_stats:read` privilege.
 
 Administration users are not affected: `increment:manage` is granted to every authenticated Administration user at runtime (the endpoints back module-usage tracking, which runs in every admin session), and `message_queue_stats:read` already is such a default privilege. Integrations and API clients calling these endpoints must have the respective privilege added to their ACL role — the runtime defaults apply to Administration users only.
+
 ### Media action routes now enforce ACL privileges
 
 The Admin API media action routes now enforce their corresponding ACL privileges. Clients must have `media:create` to upload new media, upload from a URL, or create an external media link; `media:update` to upload content to existing media or rename media; `media_thumbnail:create` or `media_thumbnail:delete` to add or remove external thumbnails; and `media:read` to use the media filename lookup route.
 
 The V2 upload and upload-from-URL routes already required `media:create` through their media repository write, and the filename lookup route already required `media:read` through its repository query. The external-link, legacy upload and rename, and external-thumbnail add and delete routes now enforce permissions that their system-scoped DAL writes did not previously require. Integrations and users that call those routes must update their ACL role.
+
 ### Template rendering endpoints require update privileges
 
 The `POST /api/_action/product-export/preview` and `POST /api/_action/product-export/validate` endpoints now require the `product_export:update` ACL privilege. The `POST /api/_action/mail-template/simulate` endpoint now requires `mail_template:update`. Admin API integrations and users that use these endpoints must be granted the respective existing privilege.
+
 ### Admin action endpoints now require ACL privileges
 
 Four admin action endpoints that previously only required authentication now enforce ACL privileges. Requests with tokens lacking the privilege receive a `403` with `FRAMEWORK__MISSING_PRIVILEGE_ERROR`:
@@ -84,6 +87,7 @@ Most extensions are not affected: OpenAPI annotations and attributes continue to
 Extensions or development tools that call swagger-php programmatically should check for removed v4/v5 APIs such as `OpenApi\Generator::scan()` and `OpenApi\Util::finder()`.
 The migration is usually straightforward because the instance API `OpenApi\Generator::generate()` is available in swagger-php 4, 5, and 6.
 See `UPGRADE-6.7.md` for concrete examples.
+
 ### Locale-aware sorting for product property group options
 
 `Shopware\Core\Content\Product\AbstractPropertyGroupSorter::sort()` is deprecated and will be removed with Shopware 6.8. Use the new `sortUsingLocaleCode()` method instead, which sorts property group options using locale-aware (ICU) collation.
@@ -180,6 +184,7 @@ Allowed directives are `cache`, `cookies` and `storage`; anything else is reject
 * `cache` makes the browser download all assets again after every logout.
 
 The header requires a trustworthy origin (HTTPS or `http://localhost`) and is ignored by Safari on the logout redirect.
+
 ### Fallback thumbnail sizes for remote thumbnails
 
 When remote thumbnails are enabled, operators can optionally configure `shopware.media.remote_thumbnails.fallback_sizes`. It defaults to `[]` and accepts entries with `width` and `height`:
@@ -210,22 +215,27 @@ Store API requests now remain stateless unless application or extension code exp
 The experimental MCP server now advertises only its default meta-tools until a client enables additional toolsets for the current MCP session. Clients can call `shopware-toolsets-list` to inspect available toolsets and `shopware-toolset-enable` to enable one. Enabling a toolset emits `notifications/tools/list_changed` so clients that support MCP list-change notifications can refresh `tools/list`.
 
 Tool execution is still bounded by the configured MCP allowlist. Enabling a toolset only changes which allowlisted tools are advertised for that session.
+
 ### MCP clients are notified when app capabilities change
 
 The experimental MCP server now queues `notifications/*/list_changed` messages for active sessions when an app's MCP tools, resources, or prompts change (install, update, activation, deactivation, deletion), so clients can refresh their discovered capabilities.
+
 ### MCP tools can be discovered on demand
 
 A fresh MCP session advertises only the three server-owned discovery meta-tools in `tools/list`: `shopware-tool-search`, `shopware-toolsets-list`, and `shopware-toolset-enable`. Every other tool is deferred and reachable in two ways: `shopware-tool-search` returns relevant tool definitions inline for a free-text query, and `shopware-toolset-enable` enables a whole toolset for the session (see the toolset section above). Tool visibility is derived solely from the tool's group — the `discovery` group is the always-advertised surface — so a tool opts into the default surface via `#[McpToolGroup('discovery')]`, not a per-tool flag.
 
 The per-integration MCP allowlist remains the call-time security boundary. `shopware-tool-search` only returns tools that are already allowed for the current integration, and tools outside the allowlist remain uncallable.
+
 ### MCP list responses apply allowlists before pagination
 
 MCP `tools/list`, `resources/list`, and `prompts/list` responses now apply the current integration allowlist before protocol pagination is calculated. Clients using `nextCursor` receive full pages of allowed capabilities instead of pages that may be partially or completely empty because hidden capabilities were filtered after paging.
+
 ### MCP tools expose a group for operator-facing selection
 
 MCP tool metadata now includes a `group` value in the `/_action/mcp/tools` and `/_action/mcp/capabilities` responses. The Administration MCP allowlist UI and `bin/console debug:mcp` use this value to group tools for operators without changing tool names or call behaviour.
 
 Tools without an explicit group derive one from the longest name prefix they share with another tool at a hyphen boundary, so tools such as `swag-my-plugin-orders` and `swag-my-plugin-products` use `swag-my-plugin` without being combined with tools from another `swag-*` extension. Existing core, plugin, and app tools continue to work.
+
 ### Product `descriptionTeaser` backfill runs once as a post-update indexer
 
 The `product.description_teaser.indexer` that fills `descriptionTeaser` for products predating the column (introduced in 6.7.12) is now a one-time post-update indexer: it runs once through the post-update flow after the update and is no longer executed by `bin/console dal:refresh:index`. It rebuilds each teaser from the current description and rewrites only the rows whose stored value is missing or out of date. Ongoing changes continue to be kept in sync synchronously on write by the product description-teaser subscriber.
@@ -257,6 +267,7 @@ The translation update orchestration was extracted into the new internal service
 ### Cloning an entity no longer fails on the write-protected `wasModifiedByUser` field
 
 Cloning any entity that carries a `wasModifiedByUser` field previously always failed with `FRAMEWORK__WRITE_CONSTRAINT_VIOLATION` on `wasModifiedByUser`, because the clone copied that write-protected field's value into the insert payload. In the Core this affected mail templates (e.g. via `POST /api/_action/clone/mail-template/{id}`), and it applies equally to any extension entity using the field. The clone process now omits the field, so the cloned entity is correctly created as a fresh, non-user-modified record. (shopware/shopware#18233)
+
 ### Standard integrations now honor `sw-app-user-id`
 
 Admin API requests authenticated with a standard integration access key now support the `sw-app-user-id` header the same way app integrations already do. When the header contains a valid user id, the resolved permissions are restricted to the intersection of the integration ACL privileges and the user's ACL privileges. Invalid or empty `sw-app-user-id` values continue to be ignored.
@@ -530,6 +541,7 @@ Also, `ProductStreamBuilderInterface` and `buildFilters()` are deprecated and wi
 Unlike `addFields()`, which is an allowlist that returns `PartialEntity` instances and drops everything not listed, `excludeFields()` returns the regular entity type (e.g. `ProductEntity`) with the excluded properties left at their default value. Typed getters, `instanceof` checks and `*.loaded` subscribers therefore keep working. It cannot be combined with `addFields()` on the same criteria, and required or write-protected top-level fields cannot be excluded — attempting to exclude one (e.g. `stock`) or an unknown field throws a `DataAbstractionLayerException`.
 
 Product listings now use this instead of the previous field allowlist: when reduced listing loading (`core.listing.partialDataLoading`) is enabled, listings load full product entities minus `description`, `keywords` and `customSearchKeywords`, so `customFields`, associations and other data remain available. As a result the `Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader::PARTIAL_LISTING_FIELDS` constant is deprecated and will be removed in `v6.8.0.0`.
+
 ### Mail template simulation supports form data
 
 Mail template simulation now provides sample data for the `contactFormData`, `reviewFormData` and `revocationRequestFormData` variables, so simulating these form templates no longer fails.
@@ -752,9 +764,11 @@ cacheService.invalidateCaches({
     cacheKey: ['custom-field-sets', 'product'],
 });
 ```
+
 ### Reworked search behaviour options
 
 The "Search behaviour" card in `Settings > Search` presents the search mode as "Broad search (OR)" and "Exact search (AND)" with short one-line descriptions, replacing the previous "OR"/"AND" labels with example texts. The broad option is now listed first; the stored configuration (`product_search_config.andLogic`) and the template blocks are unchanged. Extensions that override the mode selection (e.g. Advanced Search) can swap the offered options based on their own configuration.
+
 ### Digital product upload validation uses backend private media metadata
 
 Administration upload validation for digital products now derives private upload MIME metadata from the effective backend private extension allowlist. Extensions added through `shopware.filesystem.private_allowed_extensions` or `MediaFileExtensionWhitelistEvent` are reflected in `/api/_info/config` and in the digital-product upload UI.
@@ -1128,6 +1142,7 @@ A new `sha256` Twig filter is available alongside the existing `md5` filter. Bot
 The new `parent.name` search field allows variants to be found through their parent product name and ranked independently from the variant's own `name`.
 
 The field is disabled by default. Enable `parent.name` in the product search configuration to make this behavior active and adjust its ranking there.
+
 ### Reduced product data in listings via description teaser
 
 Product listings can now load a shortened, HTML-free excerpt of the product description instead of the full text, which significantly reduces database load, transfer size and memory usage for catalogs with large descriptions. Previously the complete description was loaded for every product box even though the storefront only displays a few clamped lines.
@@ -1742,10 +1757,12 @@ If your integration or plugin assumes a 32-character `display_group`, compares a
 ### "Find best variant setting" is now applied for storefront filtering
 
 Users can now control which representative of variant products is shown in filtered listings via the Product settings "Preview best matching variant in search results and filtered listings".
+
 ### Deprecation of `permisionsLocked` property of `SalesChannelContext`
 
 The `permisionsLocked` property of the `SalesChannelContext` is deprecated.
 Use `permissionsLocked` property or the new `SalesChannelContext::isPermissionsLocked()` getter method instead.
+
 ### Elasticsearch: Extracted field query builders from TokenQueryBuilder
 
 The `TokenQueryBuilder` has been refactored to use a decoration-based architecture for field query generation. A new `AbstractFieldQueryBuilder` abstract class serves as the public extension point, with internal implementations for:
@@ -1802,8 +1819,11 @@ The codemod converts Options API to Composition API (`data` → `ref`, `computed
 Components with `render()` functions are skipped; components using `mixins` or `Shopware.Component.extend()` receive a backoff to plain `<script>` so they can be migrated manually.
 
 See `src/Administration/Resources/app/administration/scripts/codemods/sfc-migration/README.md` for full usage, flags, and known limitations.
+
 ### [Internal] Twig to Native Block Runtime Adapter
+
 A runtime adapter has been added that bridges legacy Twig block overrides (`{% block %}` / `{% parent %}`) with the new native `<sw-block>` / `<sw-block-parent />` system. When core components migrate from `.html.twig` blocks to `<sw-block name="...">`, existing plugin overrides continue to work automatically. A deprecation warning is emitted to guide plugin developers toward the new native syntax.
+
 ### Fixed mixin-based route guards for lazy-loaded administration routes
 
 Mixin-defined route guards such as `beforeRouteLeave` are now executed reliably for lazy-loaded Administration route components.
@@ -2213,6 +2233,7 @@ We have refactored the SCSS of the checkout related routes (cart, confirm, finis
 Using `@extend` on generic tooling classes was causing very large combined selectors. We are now using the grid mixins that are documented by Bootstrap.
 
 #### Before
+
 ```scss
 .checkout-main {
     @extend .col-lg-8;
@@ -2220,6 +2241,7 @@ Using `@extend` on generic tooling classes was causing very large combined selec
 ```
 
 #### After
+
 ```scss
 .checkout-main {
     @include make-col-ready();
@@ -2284,16 +2306,19 @@ The repair runs automatically once per installation and is marked as completed i
 ## Critical Fixes
 
 ### Double signature verification in app-reregistration flow
+
 Introduces a secure, asynchronous app secret rotation feature to the app system, including both API and CLI interfaces.
 Added a new API endpoint and command for rotating app secrets, implemented the underlying rotation logic, and adjusted the app registration process to support secret updates and dual signature confirmation.
 This increases security by enforcing a two-step verification process during app re-registration, ensuring that only authorized parties can update app secrets.
 
 ### LoginRoute and AccountService don't throw CustomerNotFoundException
+
 The `LoginRoute` and `AccountService` have been updated to no longer throw a `CustomerNotFoundException` when a login attempt is made with an email address that does not exist in the system.
 Instead, they will now throw a generic `BadCredentialsException` without revealing whether the email address is registered or not.
 This change enhances security by preventing potential attackers from enumerating valid email addresses through error messages.
 
 ### Improve OrderRoute deepLinkCode filter type validation
+
 Improve the logic in `\Shopware\Core\Checkout\Order\SalesChannel\OrderRoute::load` to ensure the `deepLinkCode` filter is an instance of `\Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter`.
 
 # 6.7.8.0
@@ -2301,6 +2326,7 @@ Improve the logic in `\Shopware\Core\Checkout\Order\SalesChannel\OrderRoute::loa
 ## Features
 
 ### New internal comment for state machine state history entries
+
 A new internal comment field was added to the state change modal which can be used to add additional information about a state change.
 The internal comment is only visible in the administration and not shown to customers.
 It can be found in the state machine state history modal (state change modal) on the detail page of an order.
@@ -2670,6 +2696,7 @@ The following routes now support cache tagging, enabling automatic invalidation 
 ## Core
 
 ### Rework of DAL query generation for nested filters groups
+
 The DAL criteria builder has been adjusted to generate `EXISTS` subqueries instead of `LEFT JOIN`s for nested filter groups.
 
 Previously, each level of nested filters resulted in an additional `LEFT JOIN`, even when the join was only required to check for the existence of a related entity subject to some filter.
@@ -2826,6 +2853,7 @@ The loading spinner shown while the admin is booting up no longer spins indefini
 The cookie consent banner now tracks cookie configuration per language. Previously, switching languages would cause the cookie banner to reappear because the configuration hash changed due to translated cookie descriptions. Now, switching back to a previously accepted language will not show the banner again.
 
 The Store API endpoint `/store-api/cookie-groups` now includes a `languageId` field in the response.
+
 ### New `window.activeNavigationPathIdList` variable
 
 A new global JavaScript variable `window.activeNavigationPathIdList` is now available, containing the IDs of parent categories for the current page. This can be used by plugins or themes to implement custom navigation highlighting.
@@ -2842,11 +2870,13 @@ The following changes are relevant when HTTP caching policies feature is enabled
 * `Cache-Control` header set by policies is sent to the client for all responses, even when no reverse proxy is enabled. Previously, headers were replaced with `no-cache` when no reverse proxy was configured. **Important**: Verify your cache policy configuration is appropriate for client-side caching, as browser caches cannot be invalidated on-demand unlike reverse proxies that use tag-based invalidation.
 
 ### First tap on iOS Safari did not trigger call-to-action buttons on product detail page
+
 Fixes an issue on iOS Safari where the first tap does not trigger the desired action on the product detail page after scrolling over the image gallery.
 The `touchmove` event listener was removed from `zoom-modal.plugin.js` because it stopped the tap/click event.
 A regular `click` event is used instead to open the Zoom-Modal. The browser itself can determine via the `click` event if the user is still scrolling or clicking/taping.
 
 ### Better handling of JS plugin initialization for async content
+
 When content was loaded asyncronously within offcanvas elements or modals, all JS plugins of the page were initialized again, causing that update methods of all plugins to be called. We added a new method `initializePluginsInParentElement()` to the plugin manager to enable plugin initialization scoped to a parent element. This creates the possibility to initlize plugins only within newly added or async fetched content. The correposnding calls were updated in the following plugins:
 
 *  `ajax-offcanvas.plugin.js`
@@ -2901,17 +2931,20 @@ Additionally, the cache will be passed as soon as there is a flash message that 
 - Selected Store API routes were marked as cacheable and now support HTTP caching with Cache-Control headers.
 
 ### Send email on customer password change
+
 A new flow has been introduced which sends a confirmation email whenever a customer changes their password. This helps to identify any suspicious account activity more quickly.
 
 ## API
 
 ### Video cover management `/api/_action/media/{mediaId}/video-cover`
+
 Added endpoint to assign or remove cover images for video media files. Requires `media.editor` ACL permission.
 Accepts `coverMediaId` (string or null) in request body.
 Cover image reference is stored in `metaData.video.coverMediaId`.
 When a cover image is deleted, all video references are automatically cleaned up via `VideoCoverCleanupSubscriber`.
 
 ### StoreAPI HTTP caching support
+
 HTTP caching support was added for the following Store API endpoints:
 - `/store-api/breadcrumb/{id}`
 - `/store-api/category`
@@ -2940,12 +2973,14 @@ HTTP caching support was added for the following Store API endpoints:
 It's intended to work with the new HTTP caching policy system, and should increase performance for cacheable Store API requests.
 
 ### Store API: compressed criteria parameter support
+
 Criteria can be passed in the GET requests as single query parameter, encoded as JSON -> gzip -> base64url. This allows
 sending complex criteria without hitting URL length limits. Also, ProductListingCriteria fields are supported.
 Please note that this is a temporary workaround intended to be used until `QUERY` request method is standardized and supported.
 Check the [ADR](adr/2025-09-15-store-api-cache-strategy.md) for more details.
 
 ### Document download `/store-api/document/download/`
+
 The endpoint now selects the document file type based on the `Accept` header.
 When no `Accept` header is set or with `*/*`, `PDF` will be returned. (PR #12944)
 
@@ -3022,7 +3057,9 @@ If you have using the rule `LineItemProductStatesRule`, product stream filters, 
 If you create digital products using admin api, you should explicitly set the `type` field to `digital` when creating new products instead of relying on backend handling.
 
 ## Administration
+
 When the initial page takes more than two seconds to load, a loading indicator appears instead of a blank page.
+
 ### Axios upgrade with dual-client dispatcher
 
 The Administration now supports axios 1.x alongside the existing axios 0.30.2 to address security vulnerability CVE-2023-45857. A dual-client dispatcher pattern has been implemented that allows both versions to coexist, enabling a gradual migration path for plugins and custom code.
@@ -3292,6 +3329,7 @@ Usually inside the Twig storefront there is no need to handle the context token 
 
 
 ### Added specific `add-product-by-number` template
+
 The `page_checkout_cart_add_product*` blocks inside `@Storefront/storefront/page/checkout/cart/index.html.twig` are deprecated and a new template `@Storefront/storefront/component/checkout/add-product-by-number.html.twig` was added.
 
 Instead of overwriting any of the `page_checkout_cart_add_product*` blocks inside `@Storefront/storefront/page/checkout/cart/index.html.twig`,


### PR DESCRIPTION
### 1. Why is this change necessary?

Entries in `RELEASE_INFO-6.7.md` drifted out of a consistent shape: 21 headings sit directly on the previous entry's last paragraph with no blank line, and 17 have no blank line after the heading. It was noticed while reviewing #18631, where a new entry inherited the same pattern from its neighbour.

The `shopware-release-docs` skill says nothing about formatting, and there is no markdownlint config covering these files, so nothing steers an author (or an agent) towards the surrounding convention.

### 2. What does this change do, exactly?

- Inserts the missing blank lines in `RELEASE_INFO-6.7.md` — 21 before headings, 17 after. Whitespace only; no wording changes. `git diff` contains no non-empty added or removed lines.
- Adds a short **Formatting** section to `.agents/skills/shopware-release-docs/SKILL.md`: blank line before and after every heading, entry under the matching category of the upcoming section, code snippets kept to the shortest copyable form.
- Adds one line under a new **What To Write** heading stating that an entry covers the change and its impact rather than the reasoning behind it, the internals, or the history of the problem. This is what reviewers keep asking for in practice (for example [#18631 (comment)](https://github.com/shopware/shopware/pull/18631#discussion_r3668620133)).

Two things deliberately left out:

- Historical `UPGRADE-6.x.md` files carry the same drift at much larger scale (6.4 alone has 90 headings without a preceding blank line). They document released versions, so normalising them would be a large diff over content nobody edits.
- `delivery-process/documenting-a-release.md` still lists "Why we changed it, the benefit of the change" among the information to provide per topic, which sits in tension with the skill line added here. That file is the human process doc, so aligning it is a separate call — happy to follow up if the wording should match.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
grep -n -B1 '^### Media action routes now enforce ACL privileges' RELEASE_INFO-6.7.md
```

Before this change the preceding line is body text; after it, a blank line.

Note that GitHub renders these correctly today: CommonMark lets an ATX heading interrupt a paragraph, so this is a consistency and tooling concern (markdownlint MD022) rather than broken output.

### 4. Please link to the relevant issues (if any).

- relates #18631

### 5. Checklist

- [x] I have written tests and verified that they fail without my change — n/a, documentation and agent-skill only
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers — n/a, no externally visible behaviour changes
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
