### PR TITLE
fix(npm): raise brace-expansion override in acceptance test suite

### DIFF
--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -1415,16 +1415,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bresenham-zingl": {
@@ -4163,13 +4163,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -40,8 +40,8 @@
   },
   "overrides": {
     "follow-redirects": "1.16.0",
-    "minimatch": "10.2.4",
-    "brace-expansion": "5.0.7",
+    "minimatch": "10.2.5",
+    "brace-expansion": "5.0.8",
     "basic-ftp": "^5.3.1",
     "flatted": "3.4.2",
     "defu": "6.1.5",


### PR DESCRIPTION
### 1. Why is this change necessary?

The `Audit - Tests Acceptance` job fails on `high` severity advisory [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (`brace-expansion`: DoS via unbounded expansion length causing an out-of-memory process crash). The advisory covers `brace-expansion <= 5.0.7`, and `tests/acceptance/package.json` overrides that package to exactly `5.0.7`.

#18705 already raised the override to `5.0.8` for Administration and Storefront, but not for the acceptance test suite. Since audits on pull requests only cover changed packages, the failure currently only surfaces on PRs that touch `tests/acceptance` (e.g. #18775) and in the nightly full-matrix run.

### 2. What does this change do, exactly?

Raises the `brace-expansion` override in `tests/acceptance/package.json` from `5.0.7` to `5.0.8` (the fixed version) and refreshes the lockfile.

It also raises the `minimatch` override from `10.2.4` to `10.2.5`, the version already used in Storefront — `minimatch` is what pulls in `brace-expansion` here, and `10.2.5` requires `^5.0.5` instead of `^5.0.2`.

No `ignoredGHSAs` entries were added; the advisory is fixed upstream.

### 3. Describe each step to reproduce the issue or behaviour.

Run `node ./scripts/runNpmAudit.ts` in `tests/acceptance` on the previous dependency state:

```
Found 1 advisory affecting 1 package(s)

brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash (GHSA-mh99-v99m-4gvg)
  Package: brace-expansion <=5.0.7
  Severity: high
```

With this change it reports `No vulnerabilities (0 ignored).`

### 4. Please link to the relevant issues (if any).

- relates #18705
- relates #18775

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
