### PR TITLE
fix: Change deprecated annotation to BC attribute in EntitySearchResult

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
 use Shopware\Core\Framework\Deprecation\BCChange\ClassHierarchyChange;
+use Shopware\Core\Framework\Deprecation\BCChange\ParameterRemoval;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\StateAwareTrait;
@@ -43,10 +44,9 @@ class EntitySearchResult extends EntityCollection implements \JsonSerializable
     protected ?int $limit = null;
 
     /**
-     * @deprecated tag:v6.8.0 - The constructor signature will change in v6.8.0: the $entity parameter will be removed and the remaining parameters will reorder. See UPGRADE-6.8.md.
-     *
      * @param TEntityCollection $entities
      */
+    #[ParameterRemoval('v6.8.0', 'entity', '$entity parameter will be removed and the remaining parameters will reorder accordingly. See UPGRADE-6.8.md')]
     final public function __construct(
         /**
          * @deprecated tag:v6.8.0 - Will be removed. The entity name is no longer exposed by the result wrapper.


### PR DESCRIPTION
### 1. Why is this change necessary?

the deprecation annotation causes much noise on plugin side. 

### 2. What does this change do, exactly?

Change to new BC attribute instead

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
