### PR TITLE
fix: include folder categories in breadcrumbs

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1680,6 +1680,12 @@ To enable this feature, set the `BREADCRUMB_REWORK` feature flag to `true` and a
 
 ## API
 
+### Store API breadcrumbs include non-navigable folder categories
+
+`GET /store-api/breadcrumb/{id}` now includes folder categories in the returned hierarchy. Folder entries use `type: "folder"`, an empty `path`, and no SEO URLs.
+
+Headless storefronts and integrations must not assume every breadcrumb item is navigable; render folder entries as labels.
+
 ### SEO URL paths reject characters that are not URL-allowed on write
 
 Writes to `seo_url.seoPathInfo` now reject strings containing sequences that are not allowed in URLs: a stray `%` that does not form a valid percent-escape (`%XX`), the fragment marker `#`, backslashes, or ASCII control characters (`\x00`–`\x1F`, `\x7F`).

--- a/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
+++ b/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
@@ -305,19 +305,20 @@ class CategoryBreadcrumbBuilder
             );
 
             if ($categorySeoUrls === []) {
-                $categoryBreadcrumb->path = 'navigation/' . $categoryId;
-                continue;
-            }
-
-            foreach ($categorySeoUrls as $categorySeoUrl) {
-                if ($categoryBreadcrumb->path === '') {
-                    $categoryBreadcrumb->path = (isset($categorySeoUrl['seoPathInfo']) && $categorySeoUrl['seoPathInfo'] !== '')
-                        ? $categorySeoUrl['seoPathInfo'] : $categorySeoUrl['pathInfo'];
+                if ($category->getType() !== CategoryDefinition::TYPE_FOLDER) {
+                    $categoryBreadcrumb->path = 'navigation/' . $categoryId;
                 }
-                if ($categoryId === $categorySeoUrl['categoryId']) {
-                    unset($categorySeoUrl['categoryId']); // remove redundant data
+            } else {
+                foreach ($categorySeoUrls as $categorySeoUrl) {
+                    if ($categoryBreadcrumb->path === '') {
+                        $categoryBreadcrumb->path = (isset($categorySeoUrl['seoPathInfo']) && $categorySeoUrl['seoPathInfo'] !== '')
+                            ? $categorySeoUrl['seoPathInfo'] : $categorySeoUrl['pathInfo'];
+                    }
+                    if ($categoryId === $categorySeoUrl['categoryId']) {
+                        unset($categorySeoUrl['categoryId']); // remove redundant data
+                    }
+                    $categoryBreadcrumb->seoUrls[] = $categorySeoUrl;
                 }
-                $categoryBreadcrumb->seoUrls[] = $categorySeoUrl;
             }
 
             $seoBreadcrumbCollection[$categoryId] = $categoryBreadcrumb;

--- a/src/Storefront/Resources/views/storefront/layout/structured-data/json-ld-breadcrumb.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/structured-data/json-ld-breadcrumb.html.twig
@@ -14,9 +14,11 @@
                 {% set listItem = {
                     '@type': 'ListItem',
                     position: loop.index,
-                    name: breadcrumbCategory.name,
-                    item: seoUrl('frontend.navigation.page', { navigationId: breadcrumbCategory.categoryId })
+                    name: breadcrumbCategory.name
                 } %}
+                {% if breadcrumbCategory.type != 'folder' %}
+                    {% set listItem = listItem|merge({item: seoUrl('frontend.navigation.page', { navigationId: breadcrumbCategory.categoryId })}) %}
+                {% endif %}
             {% else %}
                 {% set listItem = {
                     '@type': 'ListItem',

--- a/src/Storefront/Resources/views/storefront/layout/structured-data/json-ld-breadcrumb.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/structured-data/json-ld-breadcrumb.html.twig
@@ -16,7 +16,7 @@
                     position: loop.index,
                     name: breadcrumbCategory.name
                 } %}
-                {% if breadcrumbCategory.type != 'folder' %}
+                {% if breadcrumbCategory.type !== 'folder' %}
                     {% set listItem = listItem|merge({item: seoUrl('frontend.navigation.page', { navigationId: breadcrumbCategory.categoryId })}) %}
                 {% endif %}
             {% else %}

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -6,8 +6,10 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Product\ProductCollection;
@@ -283,7 +285,24 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         static::assertCount(1, $firstBreadcrumb->seoUrls);
     }
 
-    public function testConvertCategoriesToBreadcrumbUrlsWithNoSeoUrls(): void
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function breadcrumbWithoutSeoUrlDataProvider(): iterable
+    {
+        yield 'page category has a navigation fallback path' => [
+            CategoryDefinition::TYPE_PAGE,
+            'navigation/019192b9cd82711482744d7b456b6c03',
+        ];
+
+        yield 'folder category has no navigable path' => [
+            CategoryDefinition::TYPE_FOLDER,
+            '',
+        ];
+    }
+
+    #[DataProvider('breadcrumbWithoutSeoUrlDataProvider')]
+    public function testConvertCategoriesToBreadcrumbUrlsWithNoSeoUrls(string $categoryType, string $expectedPath): void
     {
         $categoryEntityOne = $this->createNewCategoryEntity(
             '019192b9cd82711482744d7b456b6c03',
@@ -297,11 +316,12 @@ class CategoryBreadcrumbBuilderTest extends TestCase
                 ],
             ]
         );
+        $categoryEntityOne->setType($categoryType);
 
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock(),
+            $this->getConnectionMock([]),
             $this->entityRouteResolver,
         );
 
@@ -314,7 +334,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         static::assertArrayHasKey('name', (array) $result[0]);
         static::assertArrayHasKey('path', (array) $result[0]);
         static::assertSame('Home sweet home', $firstBreadcrumb->name);
-        static::assertSame('navigation/1', $firstBreadcrumb->path);
+        static::assertSame($expectedPath, $firstBreadcrumb->path);
+        static::assertSame([], $firstBreadcrumb->seoUrls);
     }
 
     // write a test to cover getProductBreadcrumbUrls method
@@ -370,30 +391,31 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         static::assertNull($result);
     }
 
-    private function getConnectionMock(): Connection
+    /**
+     * @param array<int, array{categoryId: string, pathInfo: string, seoPathInfo: string}> $seoUrls
+     */
+    private function getConnectionMock(array $seoUrls = [
+        [
+            'categoryId' => '019192b9cd82711482744d7b456b6c01',
+            'pathInfo' => 'pathInfo/1',
+            'seoPathInfo' => 'seoPathInfo/1',
+        ],
+        [
+            'categoryId' => '019192b9cd82711482744d7b456b6c02',
+            'pathInfo' => 'pathInfo/1',
+            'seoPathInfo' => '',
+        ],
+        [
+            'categoryId' => '019192b9cd82711482744d7b456b6c03',
+            'pathInfo' => 'navigation/1',
+            'seoPathInfo' => '',
+        ],
+    ]): Connection
     {
         $connection = static::createStub(Connection::class);
         $queryBuilder = static::createStub(QueryBuilder::class);
         $result = static::createStub(Result::class);
-        $result->method('fetchAllAssociative')->willReturn(
-            [
-                [
-                    'categoryId' => '019192b9cd82711482744d7b456b6c01',
-                    'pathInfo' => 'pathInfo/1',
-                    'seoPathInfo' => 'seoPathInfo/1',
-                ],
-                [
-                    'categoryId' => '019192b9cd82711482744d7b456b6c02',
-                    'pathInfo' => 'pathInfo/1',
-                    'seoPathInfo' => '',
-                ],
-                [
-                    'categoryId' => '019192b9cd82711482744d7b456b6c03',
-                    'pathInfo' => 'navigation/1',
-                    'seoPathInfo' => '',
-                ],
-            ]
-        );
+        $result->method('fetchAllAssociative')->willReturn($seoUrls);
 
         $queryBuilder->method('select')->willReturnSelf();
         $queryBuilder->method('executeQuery')->willReturn($result);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Folder categories were omitted from Store API breadcrumbs when they had no SEO URL. With the breadcrumb rework enabled, they were missing from the visible storefront breadcrumb but still appeared in JSON-LD with an unreachable `/navigation/<category-id>` URL.

### 2. What does this change do, exactly?

Includes folder categories in breadcrumb responses without assigning them a navigable fallback URL. JSON-LD no longer renders a navigation URL for folder entries.

### 3. Describe each step to reproduce the issue or behaviour.

Enable the following feature flags:
```
JSON_LD_DATA=1
BREADCRUMB_REWORK=1
```

1. Create a category with type folder.
2. Create a child category with type page.
3. Navigate to the child category.
4. The folder is missing from the storefront breadcrumb. 
5. It is present in the JSON-LD breadcrumb data, but its generated URL is unreachable (404).

The Store API reproduces the underlying issue without feature flags:
```
curl -sS \
  -H 'sw-access-key: <sw-access-key>' \
  'https://web.shopware.orb.local/store-api/breadcrumb/<child-category-id>?type=category'
```

Before this change, the folder is not included in the response. After this change, it is returned as a non-navigable breadcrumb entry.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #18170

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
