### PR TITLE
test: avoid deprecated EntitySearchResult::first() in DocumentV2 tests

### DIFF
--- a/tests/integration/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Controller/DocumentV2ControllerTest.php
@@ -218,8 +218,7 @@ class DocumentV2ControllerTest extends TestCase
         static::assertIsString($payload['documentId'] ?? null);
 
         $document = static::getContainer()->get('document.repository')
-            ->search(new Criteria([$payload['documentId']]), $this->context)
-            ->first();
+            ->search(new Criteria([$payload['documentId']]), $this->context)->getEntities()->first();
 
         static::assertInstanceOf(DocumentEntity::class, $document);
         static::assertSame($invoiceId, $document->getReferencedDocumentId());

--- a/tests/integration/Core/Checkout/DocumentV2/Generation/DocumentGeneratorTest.php
+++ b/tests/integration/Core/Checkout/DocumentV2/Generation/DocumentGeneratorTest.php
@@ -275,8 +275,7 @@ class DocumentGeneratorTest extends TestCase
     private function loadDocument(string $documentId): DocumentEntity
     {
         $document = static::getContainer()->get('document.repository')
-            ->search(new Criteria([$documentId]), $this->context)
-            ->first();
+            ->search(new Criteria([$documentId]), $this->context)->getEntities()->first();
 
         static::assertInstanceOf(DocumentEntity::class, $document);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Without this, major Nightly will fail & any PR using the `major-php` label will have its pipeline failing

[2 DocumentV2 integration tests](https://github.com/shopware/shopware/pull/18649/changes#diff-f3acc64007ec6151e61cb06c2d895414076a9e46fffe30c76d4ef5a44fd9dd12R222) call the deprecated `EntitySearchResult::first()` directly on the search result. 

Both static guards miss it: the Rector rule cannot resolve the receiver type behind `static::getContainer()->get('document.repository')` (addressed in #18836), and PHPStan swallows the deprecation via the blanket `#deprecated.*(class|interface) Shopware\\#` ignore pattern in `phpstan.neon.dist`.

⚠️ Note: this could have been avoided running the PR with `major-php` label, this one triggering a job with major tests. There is an automatic detection, but it cannot catch everything (and so far we didn't want to _always_ run those jobs)


### 2. What does this change do, exactly?

Rewrites the two call sites to `->getEntities()->first()`, the replacement the deprecation prescribes.

### 3. Describe each step to reproduce the issue or behaviour.

Not a runtime issue; the deprecated delegation still behaves identically until its removal in 6.8. Both test classes pass unchanged (11 tests, 104 assertions).

### 4. Please link to the relevant issues (if any).

- relates #18836 (this will fix why Rector did not catch this)
- follow up of #18649
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
