### PR TITLE
fix: order cookie consent after skip links

### DIFF
--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -28,17 +28,17 @@
         {%- if activeRoute is not empty -%}is-active-route-{{ activeRoute|replace({'.': '-'}) }}{%- endif -%}
     {%- endblock %}">
 
-    {# @deprecated tag:v6.8.0 - Cookie permission bar "base_cookie_permission" will be moved to this position. #}
-    {% if feature('v6.8.0.0') %}
-        {{ sw_block('base_cookie_permission') }}
-    {% endif %}
-
     {% block base_body_skip_to_content %}
         {% sw_include '@Storefront/storefront/component/skip-to-content.html.twig' with {
             skipToSearch: true,
             skipToMainNav: true
         } %}
     {% endblock %}
+
+    {# @deprecated tag:v6.8.0 - Cookie permission bar "base_cookie_permission" will be moved to this position. #}
+    {% if feature('v6.8.0.0') %}
+        {{ sw_block('base_cookie_permission') }}
+    {% endif %}
 
     {% block base_body_inner %}
         {% block base_noscript %}

--- a/src/Storefront/Resources/views/storefront/layout/cookie/cookie-permission.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/cookie/cookie-permission.html.twig
@@ -4,7 +4,7 @@
 
 {% if useDefaultCookieConsent %}
     {% set cookiePermissionOptions = {
-        autoFocus: true,
+        autoFocus: false,
     } %}
 
     {% block layout_cookie_permission_inner %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Accessibility best practice is to place skip links first in the document and keyboard-focus order. The cookie consent banner currently precedes them and receives focus automatically, forcing keyboard and screen-reader users to encounter its controls before they can use skip navigation.

### 2. What does this change do, exactly?

Moves the cookie consent banner directly after the skip links in the document order and disables its automatic focus. This preserves the recommended sequence: skip links, cookie consent controls, then the rest of the page.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a storefront page without a stored cookie preference.
2. Navigate with the keyboard from the start of the page.
3. Before this change, focus is moved directly to the cookie consent banner.
4. With this change, the skip links are encountered first, followed by the cookie consent controls.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #18165

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
