### PR TITLE
fix(administration): populate default address checkboxes for order address snapshots

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form-options/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form-options/index.js
@@ -47,8 +47,27 @@ export default {
 
     methods: {
         createdComponent() {
-            this.isDefaultShippingAddressId = this.customer.defaultShippingAddressId === this.address.id;
-            this.isDefaultBillingAddressId = this.customer.defaultBillingAddressId === this.address.id;
+            this.isDefaultShippingAddressId = this.isDefaultAddress(this.customer.defaultShippingAddressId);
+            this.isDefaultBillingAddressId = this.isDefaultAddress(this.customer.defaultBillingAddressId);
+        },
+
+        isDefaultAddress(defaultAddressId) {
+            if (!defaultAddressId) {
+                return false;
+            }
+
+            if (defaultAddressId === this.address.id) {
+                return true;
+            }
+
+            // Order addresses are snapshots with their own id; match them to the default by content hash.
+            if (this.customer.addresses?.has(this.address.id)) {
+                return false;
+            }
+
+            const defaultAddress = this.customer.addresses?.get(defaultAddressId);
+
+            return Boolean(this.address.hash && defaultAddress?.hash === this.address.hash);
         },
 
         onChangeDefaultShippingAddress(active) {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form-options/sw-customer-address-form-options.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-address-form-options/sw-customer-address-form-options.spec.js
@@ -4,13 +4,27 @@ import { mount } from '@vue/test-utils';
  * @sw-package checkout
  */
 
+/**
+ * Builds a minimal stand-in for a DAL EntityCollection exposing the `has`/`get`
+ * lookups the component relies on.
+ */
+function createAddressCollection(addresses = []) {
+    return {
+        has: (id) => addresses.some((address) => address.id === id),
+        get: (id) => addresses.find((address) => address.id === id) ?? null,
+    };
+}
+
 async function createWrapper(props = {}) {
     return mount(await wrapTestComponent('sw-customer-address-form-options', { sync: true }), {
         global: {
             stubs: {
                 'mt-checkbox': {
-                    props: ['disabled'],
-                    template: '<input class="mt-checkbox" :disabled="disabled">',
+                    props: [
+                        'checked',
+                        'disabled',
+                    ],
+                    template: '<input type="checkbox" class="mt-checkbox" :checked="checked" :disabled="disabled">',
                 },
                 'sw-custom-field-set-renderer': {
                     name: 'sw-custom-field-set-renderer',
@@ -43,5 +57,77 @@ describe('module/sw-customer/component/sw-customer-address-form-options', () => 
             expect(checkbox.props('disabled')).toBe(true);
         });
         expect(wrapper.getComponent('.sw-custom-field-set-renderer').props('disabled')).toBe(true);
+    });
+
+    it('should check the boxes when the edited customer address is the default via id', async () => {
+        const wrapper = await createWrapper({
+            address: { id: 'shipping-address-id' },
+        });
+
+        expect(wrapper.vm.isDefaultShippingAddressId).toBe(true);
+        expect(wrapper.vm.isDefaultBillingAddressId).toBe(false);
+    });
+
+    it('should leave the boxes unchecked when the address is neither the default nor a matching snapshot', async () => {
+        const wrapper = await createWrapper({
+            address: { id: 'unrelated-address-id', hash: 'unrelated-hash' },
+        });
+
+        expect(wrapper.vm.isDefaultShippingAddressId).toBe(false);
+        expect(wrapper.vm.isDefaultBillingAddressId).toBe(false);
+    });
+
+    it('should check the boxes for an order address snapshot matching the default by content hash', async () => {
+        const wrapper = await createWrapper({
+            customer: {
+                defaultShippingAddressId: 'shipping-address-id',
+                defaultBillingAddressId: 'billing-address-id',
+                addresses: createAddressCollection([
+                    { id: 'shipping-address-id', hash: 'shipping-hash' },
+                    { id: 'billing-address-id', hash: 'billing-hash' },
+                ]),
+            },
+            // Order addresses are snapshot copies with their own id but the same content hash.
+            address: { id: 'order-address-id', hash: 'shipping-hash' },
+        });
+
+        expect(wrapper.vm.isDefaultShippingAddressId).toBe(true);
+        expect(wrapper.vm.isDefaultBillingAddressId).toBe(false);
+    });
+
+    it('should not check the boxes for an order address snapshot whose hash differs from the default', async () => {
+        const wrapper = await createWrapper({
+            customer: {
+                defaultShippingAddressId: 'shipping-address-id',
+                defaultBillingAddressId: 'billing-address-id',
+                addresses: createAddressCollection([
+                    { id: 'shipping-address-id', hash: 'shipping-hash' },
+                    { id: 'billing-address-id', hash: 'billing-hash' },
+                ]),
+            },
+            address: { id: 'order-address-id', hash: 'outdated-hash' },
+        });
+
+        expect(wrapper.vm.isDefaultShippingAddressId).toBe(false);
+        expect(wrapper.vm.isDefaultBillingAddressId).toBe(false);
+    });
+
+    it('should not hash-match a stored customer address that only shares its content with the default', async () => {
+        const wrapper = await createWrapper({
+            customer: {
+                defaultShippingAddressId: 'shipping-address-id',
+                defaultBillingAddressId: 'billing-address-id',
+                addresses: createAddressCollection([
+                    { id: 'shipping-address-id', hash: 'shared-hash' },
+                    { id: 'billing-address-id', hash: 'billing-hash' },
+                    // A distinct stored address with identical content to the default.
+                    { id: 'duplicate-address-id', hash: 'shared-hash' },
+                ]),
+            },
+            address: { id: 'duplicate-address-id', hash: 'shared-hash' },
+        });
+
+        expect(wrapper.vm.isDefaultShippingAddressId).toBe(false);
+        expect(wrapper.vm.isDefaultBillingAddressId).toBe(false);
     });
 });


### PR DESCRIPTION



<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Order addresses are snapshot copies with their own id, so comparing `customer.defaultShippingAddressId/defaultBillingAddressId` against the edited address id never matched for an order address. As a result the "Set as default delivery/billing address" checkboxes stayed unchecked in the order detail even when the address originated from a default set in the storefront

### 2. What does this change do, exactly?
Fall back to matching the customer's default address by content hash (the same mechanism sw-order-address-selection already uses to dedupe addresses) when the edited address is a snapshot rather than a stored customer address

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #18695
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
