### PR TITLE
refactor(core): replace count() checks with empty array comparisons

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackageRules.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackageRules.php
@@ -33,7 +33,7 @@ class AdvancedPackageRules extends SetGroupScopeFilter
         foreach ($packages as $package) {
             [$metaData, $cartItems] = $this->filterPackage($package, $discount->getPriceDefinition(), $context);
 
-            if (\count($metaData) > 0) {
+            if ($metaData !== []) {
                 $filtered->add($this->createFilteredValuesPackage($metaData, $cartItems));
             }
         }

--- a/src/Core/Framework/Plugin/Composer/PackageProvider.php
+++ b/src/Core/Framework/Plugin/Composer/PackageProvider.php
@@ -27,7 +27,7 @@ class PackageProvider
             throw PluginException::composerJsonInvalid($composerJsonPath, $errors);
         }
 
-        if (\count($warnings) !== 0) {
+        if ($warnings !== []) {
             $warningsString = implode("\n", $warnings);
             $composerIO->write(\sprintf("Attention!\nThe '%s' has some warnings:\n%s", $composerJsonPath, $warningsString));
         }


### PR DESCRIPTION
### 1. Why is this change necessary?

While fixing container-aware type inference in the Rector analysis (#18836), `CountArrayToEmptyArrayComparisonRector` flags 2 production files that previously passed unflagged, so the Rector job on that PR is red.

### 2. What does this change do, exactly?

Applies the rewrites Rector proposes, matching the empty-array comparison style already used in the surrounding code:

- `src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackageRules.php`: `\count($metaData) > 0` becomes `$metaData !== []`
- `src/Core/Framework/Plugin/Composer/PackageProvider.php`: `\count($warnings) !== 0` becomes `$warnings !== []`

### 3. Describe each step to reproduce the issue or behaviour.

1. Check out #18836 and run `composer rector`.
2. The dry run reports the two `CountArrayToEmptyArrayComparisonRector` findings above and exits with code 2: https://github.com/shopware/shopware/actions/runs/30547999316/job/90889126106
3. With this change merged, the same run reports no findings for these files.

### 4. Please link to the relevant issues (if any).

Unblocks the Rector job on #18836.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
