### PR TITLE
ci: pin rector toolchain versions

### DIFF
--- a/vendor-bin/rector/composer.json
+++ b/vendor-bin/rector/composer.json
@@ -1,7 +1,8 @@
 {
     "require-dev": {
-        "frosh/shopware-rector": "^0.5.10",
-        "rector/rector": "^2.3.6"
+        "frosh/shopware-rector": "0.5.10",
+        "phpstan/phpstan": "2.2.5",
+        "rector/rector": "2.5.7"
     },
     "sort-packages": true
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

To prevent unwanted sudden failure, due to PHPStan dependency (which is pinned itself on main composer.json) we pin the vendor-bin of rector

`vendor-bin/**/composer.lock` is gitignored, so CI resolves the Rector toolchain fresh on every run and the caret constraints float to the latest releases. Upstream releases therefore change CI behavior without any repo change.

This happened already with: 
phpstan 2.2.7 (released 2026-07-29) changed native type resolution so that 2 latent CountArrayToEmptyArrayComparisonRector` finding. `src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackageRules.php:33`, `src/Core/Framework/Plugin/Composer/PackageProvider.php:27

Was firing on any cold Rector run, trunk included. 
Warm result-cache runs mask this until the next `rector.php` change or cache eviction.

### 2. What does this change do, exactly?

Pins the toolchain to the exact versions that cold-run green today, and adds `phpstan/phpstan` as a direct requirement so the transitive version is controlled:

- `frosh/shopware-rector` `^0.5.10` -> `0.5.10`
- `phpstan/phpstan` (transitive) -> `2.2.5`
- `rector/rector` `^2.3.6` -> `2.5.7`

This matches the root `composer.json` policy of pinning the phpstan family exactly. Toolchain upgrades become deliberate bump PRs whose cold-run effects are visible in that PR's Rector job instead of appearing on unrelated branches.

### 3. Describe each step to reproduce the issue or behaviour.

1. Invalidate the Rector result cache (any edit to `rector.php` changes the config hash).
2. Run `composer rector` before this pin: the resolver picks phpstan 2.2.7 and the job reports the two findings above without any code change having introduced them.
3. With this pin, the same cold run stays green; upgrading the pins reproduces the findings deterministically.

### 4. Please link to the relevant issues (if any).

- relates #18836

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
