### PR TITLE
fix: Return integer counts from MySQLIncrementer

### DIFF
--- a/src/Core/Framework/Increment/MySQLIncrementer.php
+++ b/src/Core/Framework/Increment/MySQLIncrementer.php
@@ -122,7 +122,7 @@ class MySQLIncrementer extends AbstractIncrementer
             ];
         }
 
-        /** @var array<string, array{count: int|string, key: string, cluster: string, pool: string}> $result */
+        /** @var array<string, array{count: string, key: string, cluster: string, pool: string}> $result */
         $result = $this->connection->fetchAllAssociativeIndexed($sql, $payload, $types);
 
         foreach ($result as $key => $row) {

--- a/src/Core/Framework/Increment/MySQLIncrementer.php
+++ b/src/Core/Framework/Increment/MySQLIncrementer.php
@@ -122,8 +122,12 @@ class MySQLIncrementer extends AbstractIncrementer
             ];
         }
 
-        /** @var array<string, array{count: int, key: string, cluster: string, pool: string}> $result */
+        /** @var array<string, array{count: int|string, key: string, cluster: string, pool: string}> $result */
         $result = $this->connection->fetchAllAssociativeIndexed($sql, $payload, $types);
+
+        foreach ($result as $key => $row) {
+            $result[$key]['count'] = max(0, (int) $row['count']);
+        }
 
         return $result;
     }

--- a/tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php
+++ b/tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php
@@ -32,13 +32,13 @@ class MySQLIncrementerTest extends TestCase
         $list = $this->mysqlIncrementer->list('test-user-1');
 
         static::assertNotNull($list['sw.product.index']);
-        static::assertSame('1', $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->increment('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('2', $list['sw.product.index']['count']);
+        static::assertSame(2, $list['sw.product.index']['count']);
     }
 
     public function testDecrement(): void
@@ -49,13 +49,13 @@ class MySQLIncrementerTest extends TestCase
         $list = $this->mysqlIncrementer->list('test-user-1');
 
         static::assertNotNull($list['sw.product.index']);
-        static::assertSame('2', $list['sw.product.index']['count']);
+        static::assertSame(2, $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->decrement('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('1', $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
     }
 
     public function testList(): void
@@ -66,9 +66,9 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('2', array_values($list)[0]['count']);
+        static::assertSame(2, array_values($list)[0]['count']);
         static::assertSame('sw.product.index', array_values($list)[0]['key']);
-        static::assertSame('1', array_values($list)[1]['count']);
+        static::assertSame(1, array_values($list)[1]['count']);
 
         // List will return in DESC order of record's count
         $this->mysqlIncrementer->increment('test-user-1', 'sw.order.index');
@@ -76,9 +76,9 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('3', array_values($list)[0]['count']);
+        static::assertSame(3, array_values($list)[0]['count']);
         static::assertSame('sw.order.index', array_values($list)[0]['key']);
-        static::assertSame('2', array_values($list)[1]['count']);
+        static::assertSame(2, array_values($list)[1]['count']);
     }
 
     public function testReset(): void
@@ -94,22 +94,22 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('0', $list['sw.product.index']['count']);
+        static::assertSame(0, $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->increment('test-user-1', 'sw.order.index');
         $this->mysqlIncrementer->increment('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('1', $list['sw.product.index']['count']);
-        static::assertSame('1', $list['sw.order.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.order.index']['count']);
 
         $this->mysqlIncrementer->reset('test-user-1', 'sw.order.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('1', $list['sw.product.index']['count']);
-        static::assertSame('0', $list['sw.order.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
+        static::assertSame(0, $list['sw.order.index']['count']);
     }
 
     public function testDeleteKeys(): void
@@ -130,7 +130,7 @@ class MySQLIncrementerTest extends TestCase
                 'pool' => 'user-activity-pool',
                 'cluster' => 'test-user-1',
                 'key' => 'sw.product.create',
-                'count' => '1',
+                'count' => 1,
             ],
         ], $list);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

`AbstractIncrementer::list()` documents its return shape as `array{count: int, key: string, cluster: string, pool: string}`, and `ArrayIncrementer` returns integer counts accordingly. `MySQLIncrementer::list()` however returns the raw DBAL result, where `count` is a string. Consumers of the increment gateway therefore receive different types for the same value depending on which gateway is configured, and the docblock contract is violated for the `mysql` gateway.

This is the first of three follow-up PRs splitting up #14583, as requested in its review.

### 2. What does this change do, exactly?

- Normalizes `count` to a non-negative integer in `MySQLIncrementer::list()`, so it fulfills the documented contract of `AbstractIncrementer::list()` and behaves consistently with `ArrayIncrementer`.
- Updates the assertions in `MySQLIncrementerTest` to expect integer counts, mirroring the existing `ArrayIncrementerTest` assertions.

The change is covered by the (adjusted) `MySQLIncrementerTest` integration test; per the testing guidelines, DBAL-based adapters are intentionally covered by integration tests instead of unit tests with a mocked `Connection`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure an increment pool with `type: 'mysql'` (the default for `user_activity`).
2. Call `increment()` and then `list()` on the gateway.
3. Observe that `count` is the string `'1'`, while `ArrayIncrementer` returns `int(1)` for the same operations and the docblock promises `int`.

Alternatively: run `tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php` from this PR without the `src` change — the type-strict assertions fail.

### 4. Please link to the relevant issues (if any).

- relates #14455
- relates #13921
- split out of #14583 (part 1 of 3)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
