### PR TITLE
ci: patch vendored composer in the update test base installation

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -338,6 +338,13 @@ jobs:
 
           composer require shopware/core:${{ matrix.update.version }}
 
+      # setup-shopware only patches new-shopware; this installation vendors its own
+      # composer/composer, which for older versions predates composer/composer#12856.
+      - name: Patch vendored composer for modern GitHub tokens
+        uses: shopware/setup-shopware/patch-composer@main
+        with:
+          path: old-shopware
+
       - name: Install
         working-directory: old-shopware
         run: |


### PR DESCRIPTION
### 1. Why is this change necessary?

`acceptance-update (v6.6.0.0)` fails in `Install` on every 6.6.x run since 2026-07-30: `Your github oauth token for github.com contains invalid characters: "ghs_15***"`.

`setup-shopware` patches the vendored `composer/composer` of `new-shopware`, but `old-shopware` is built afterwards via `composer require` and vendors its own copy — 2.8.11 for v6.6.0.0, which predates composer/composer#12856. Bumping it isn't possible: v6.6.0.0 pins Symfony to `~7.0`, composer >= 2.9 needs `symfony/console ^7.1.10`. The other two matrix entries get 2.10.2 and are unaffected.

### 2. What does this change do, exactly?

Applies the same patch to `old-shopware` after `composer require`, via the action from shopware/setup-shopware#49. No-op for composer >= 2.10.

**Depends on shopware/setup-shopware#49** — draft until that is merged.

### 3. Describe each step to reproduce the issue or behaviour.

Run `acceptance-update` on 6.6.x, e.g. the nightly https://github.com/shopware/shopware/actions/runs/30597732919.

### 4. Please link to the relevant issues (if any).

- relates shopware/setup-shopware#49

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change <!-- CI-only change -->
- [ ] I have created a changelog file <!-- not applicable for CI changes -->
- [ ] I have written or adjusted the documentation according to my changes <!-- documented in the setup-shopware README -->
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.