### PR TITLE
feat(discovery): config to opt out of path cache busting for media

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -33,6 +33,10 @@ The new privileges are part of the existing "Plugin maintain" (`system:app:chang
 
 ## Core
 
+### Media path cache busting is configurable
+
+The new `shopware.cdn.path_cache_buster` setting defaults to `true`, preserving timestamped media paths. Set it to `false` to keep paths stable for future media uploads and replacements while retaining `?ts=` query-string cache busting. Configure the CDN to include query strings in its cache key. Existing media paths are not migrated.
+
 ### `product-export:generate --force` now regenerates scheduler-managed exports
 
 `--force` promises to ignore the cache and force generation, but for scheduler-managed exports it was a no-op. This aligns the flag with its documented behavior.

--- a/src/Core/Content/DependencyInjection/media_path.php
+++ b/src/Core/Content/DependencyInjection/media_path.php
@@ -83,15 +83,27 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ]);
 
     $services->set(FilenamePathStrategy::class)
+        ->args([
+            '$pathCacheBuster' => param('shopware.cdn.path_cache_buster'),
+        ])
         ->tag('shopware.path.strategy');
 
     $services->set(IdPathStrategy::class)
+        ->args([
+            '$pathCacheBuster' => param('shopware.cdn.path_cache_buster'),
+        ])
         ->tag('shopware.path.strategy');
 
     $services->set(PhysicalFilenamePathStrategy::class)
+        ->args([
+            '$pathCacheBuster' => param('shopware.cdn.path_cache_buster'),
+        ])
         ->tag('shopware.path.strategy');
 
     $services->set(PlainPathStrategy::class)
+        ->args([
+            '$pathCacheBuster' => param('shopware.cdn.path_cache_buster'),
+        ])
         ->tag('shopware.path.strategy');
 
     $services->set(AbstractMediaUrlGenerator::class, MediaUrlGenerator::class)

--- a/src/Core/Content/Media/Core/Application/AbstractMediaPathStrategy.php
+++ b/src/Core/Content/Media/Core/Application/AbstractMediaPathStrategy.php
@@ -18,6 +18,14 @@ use Shopware\Core\Framework\Util\Hasher;
 abstract class AbstractMediaPathStrategy
 {
     /**
+     * @internal
+     */
+    public function __construct(
+        private readonly bool $pathCacheBuster = true,
+    ) {
+    }
+
+    /**
      * The function has to generate the path for the provided locations
      *
      * Called when the media was uploaded or when the media will be renamed.
@@ -70,6 +78,10 @@ abstract class AbstractMediaPathStrategy
 
     protected function cacheBuster(MediaLocationStruct|ThumbnailLocationStruct $location): ?string
     {
+        if (!$this->pathCacheBuster) {
+            return null;
+        }
+
         $media = $location instanceof MediaLocationStruct ? $location : $location->media;
 
         return $media->uploadedAt ? (string) $media->uploadedAt->getTimestamp() : null;

--- a/src/Core/Content/Media/Core/Strategy/PhysicalFilenamePathStrategy.php
+++ b/src/Core/Content/Media/Core/Strategy/PhysicalFilenamePathStrategy.php
@@ -22,8 +22,8 @@ class PhysicalFilenamePathStrategy extends AbstractMediaPathStrategy
     {
         $media = $location instanceof ThumbnailLocationStruct ? $location->media : $location;
 
-        $timestamp = $media->uploadedAt ? $media->uploadedAt->getTimestamp() . '/' : '';
+        $timestamp = $this->cacheBuster($location);
 
-        return $timestamp . $media->fileName;
+        return ($timestamp !== null ? $timestamp . '/' : '') . $media->fileName;
     }
 }

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -157,6 +157,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('url')->end()
                 ->scalarNode('strategy')->end()
+                ->booleanNode('path_cache_buster')->defaultTrue()->end()
                 ->arrayNode('fastly')
                     ->children()
                         ->scalarNode('api_key')->end()

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -200,6 +200,7 @@ shopware:
     cdn:
         url: ''
         strategy: "%env(string:default:default_cdn_strategy:SHOPWARE_CDN_STRATEGY_DEFAULT)%"
+        path_cache_buster: true
         fastly:
             api_key: ''
             soft_purge: false

--- a/tests/unit/Core/Content/Media/Core/Strategy/FilenamePathStrategyTest.php
+++ b/tests/unit/Core/Content/Media/Core/Strategy/FilenamePathStrategyTest.php
@@ -69,4 +69,18 @@ class FilenamePathStrategyTest extends TestCase
             'media/fd/18/g0/1609459200/018b3c6d2ddf726fb12ee582f5caba40.jpg',
         ];
     }
+
+    public function testStrategyWithoutPathCacheBuster(): void
+    {
+        $strategy = new FilenamePathStrategy(false);
+
+        static::assertSame(
+            ['foo' => 'media/09/8f/6b/test.jpg'],
+            $strategy->generate([new MediaLocationStruct('foo', 'jpg', 'test', new \DateTimeImmutable('2021-01-01'))])
+        );
+        static::assertSame(
+            ['thumbnail' => 'thumbnail/09/8f/6b/test_100x100.jpg'],
+            $strategy->generate([new ThumbnailLocationStruct('thumbnail', 100, 100, new MediaLocationStruct('foo', 'jpg', 'test', new \DateTimeImmutable('2021-01-01')))])
+        );
+    }
 }

--- a/tests/unit/Core/Content/Media/Core/Strategy/IdPathStrategyTest.php
+++ b/tests/unit/Core/Content/Media/Core/Strategy/IdPathStrategyTest.php
@@ -66,4 +66,18 @@ class IdPathStrategyTest extends TestCase
             'media/fd/18/g0/1609459200/test.jpg',
         ];
     }
+
+    public function testStrategyWithoutPathCacheBuster(): void
+    {
+        $strategy = new IdPathStrategy(false);
+
+        static::assertSame(
+            ['foo' => 'media/ac/bd/18/test.jpg'],
+            $strategy->generate([new MediaLocationStruct('foo', 'jpg', 'test', new \DateTimeImmutable('2021-01-01'))])
+        );
+        static::assertSame(
+            ['thumbnail' => 'thumbnail/ac/bd/18/test_100x100.jpg'],
+            $strategy->generate([new ThumbnailLocationStruct('thumbnail', 100, 100, new MediaLocationStruct('foo', 'jpg', 'test', new \DateTimeImmutable('2021-01-01')))])
+        );
+    }
 }

--- a/tests/unit/Core/Content/Media/Core/Strategy/PhysicalFilenamePathStrategyTest.php
+++ b/tests/unit/Core/Content/Media/Core/Strategy/PhysicalFilenamePathStrategyTest.php
@@ -66,4 +66,18 @@ class PhysicalFilenamePathStrategyTest extends TestCase
             'media/5c/4d/dc/1609459200/018b3c6d2ddf726fb12ee582f5caba40.jpg',
         ];
     }
+
+    public function testStrategyWithoutPathCacheBuster(): void
+    {
+        $strategy = new PhysicalFilenamePathStrategy(false);
+
+        static::assertSame(
+            ['foo' => 'media/09/8f/6b/test.jpg'],
+            $strategy->generate([new MediaLocationStruct('foo', 'jpg', 'test', new \DateTimeImmutable('2021-01-01'))])
+        );
+        static::assertSame(
+            ['thumbnail' => 'thumbnail/09/8f/6b/test_100x100.jpg'],
+            $strategy->generate([new ThumbnailLocationStruct('thumbnail', 100, 100, new MediaLocationStruct('foo', 'jpg', 'test', new \DateTimeImmutable('2021-01-01')))])
+        );
+    }
 }

--- a/tests/unit/Core/Content/Media/Core/Strategy/PlainPathStrategyTest.php
+++ b/tests/unit/Core/Content/Media/Core/Strategy/PlainPathStrategyTest.php
@@ -62,4 +62,18 @@ class PlainPathStrategyTest extends TestCase
             'thumbnail/1609459200/test_100x100.jpg',
         ];
     }
+
+    public function testStrategyWithoutPathCacheBuster(): void
+    {
+        $strategy = new PlainPathStrategy(false);
+
+        static::assertSame(
+            ['foo' => 'media/test.jpg'],
+            $strategy->generate([new MediaLocationStruct('foo', 'jpg', 'test', new \DateTimeImmutable('2021-01-01'))])
+        );
+        static::assertSame(
+            ['thumbnail' => 'thumbnail/test_100x100.jpg'],
+            $strategy->generate([new ThumbnailLocationStruct('thumbnail', 100, 100, new MediaLocationStruct('foo', 'jpg', 'test', new \DateTimeImmutable('2021-01-01')))])
+        );
+    }
 }

--- a/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
@@ -51,6 +51,13 @@ class ConfigurationTest extends TestCase
         static::assertInstanceOf(BooleanNodeDefinition::class, $node);
     }
 
+    public function testCdnPathCacheBusterDefaultsToTrue(): void
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(), [['cdn' => []]]);
+
+        static::assertTrue($config['cdn']['path_cache_buster']);
+    }
+
     public function testTranslationConfigTreeNode(): void
     {
         $configuration = new Configuration();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Media replacement currently changes both the physical path and the ts query parameter. URLs retained in cached pages, emails, or search indexes can therefore point to a deleted object and return 404.

### 2. What does this change do, exactly?

Adds the opt-in `shopware.cdn.path_cache_buster` configuration, defaulting to true.
When disabled, media and thumbnail paths remain stable on replacement while the existing ?ts= query parameter continues to provide cache busting. This applies to all built-in media path strategies, including physical_filename.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure `shopware.cdn.path_cache_buster: false`.
2. Upload or replace a media item.
3. Replace the same media item again.
4. Verify its stored path remains unchanged while the generated URL's ts parameter changes.
5. Verify the prior URL still resolves instead of returning 404.

### 4. Please link to the relevant issues (if any).

fixes https://github.com/shopware/saas/issues/703

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
