### PR TITLE
ci: docker workflow for visual tests now runs without grep input

### DIFF
--- a/.github/workflows/visual-tests-docker.yml
+++ b/.github/workflows/visual-tests-docker.yml
@@ -37,6 +37,7 @@ jobs:
             echo "BLUE_GREEN_DEPLOYMENT=1"
             echo "ENABLE_SERVICES=0"
           } >> "$GITHUB_ENV"
+      
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
@@ -54,11 +55,12 @@ jobs:
           npm config set fetch-retries 5
           npm config set fetch-retry-mintimeout 20000
           npm ci
+      
       - name: Run visual tests in Playwright container
         working-directory: tests/acceptance
         continue-on-error: true
         env:
-          UPDATE_SNAPSHOTS: ${{ inputs.update-snapshots && '--update-snapshots' || '' }}
+          UPDATE_SNAPSHOTS: ${{ inputs.update-snapshots && '--update-snapshots=all' || '--update-snapshots=none' }}
           FILTER: ${{ inputs.filter && format('--grep={0}', inputs.filter) || '' }}
           CURRENTS_PROJECT_ID: ${{ secrets.CURRENTS_PROJECT_ID_VISUAL }}
           CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
@@ -80,7 +82,8 @@ jobs:
             -v "$GITHUB_WORKSPACE:/app" \
             -w /app/tests/acceptance \
             "mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble" \
-            npx "$ATS_CMD" test --project=Visual --workers=1"$UPDATE_SNAPSHOTS""$FILTER"
+            npx "$ATS_CMD" test --project=Visual --workers=1 "$UPDATE_SNAPSHOTS" "$FILTER"
+      
       - name: Upload visual test results
         if: always()
         continue-on-error: true

--- a/.github/workflows/visual-tests-docker.yml
+++ b/.github/workflows/visual-tests-docker.yml
@@ -80,7 +80,7 @@ jobs:
             -v "$GITHUB_WORKSPACE:/app" \
             -w /app/tests/acceptance \
             "mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble" \
-            npx "$ATS_CMD" test --project=Visual --workers=1 "$UPDATE_SNAPSHOTS" "$FILTER"
+            npx "$ATS_CMD" test --project=Visual --workers=1"$UPDATE_SNAPSHOTS""$FILTER"
       - name: Upload visual test results
         if: always()
         continue-on-error: true

--- a/.github/workflows/visual-tests-docker.yml
+++ b/.github/workflows/visual-tests-docker.yml
@@ -37,7 +37,6 @@ jobs:
             echo "BLUE_GREEN_DEPLOYMENT=1"
             echo "ENABLE_SERVICES=0"
           } >> "$GITHUB_ENV"
-      
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
@@ -55,7 +54,6 @@ jobs:
           npm config set fetch-retries 5
           npm config set fetch-retry-mintimeout 20000
           npm ci
-      
       - name: Run visual tests in Playwright container
         working-directory: tests/acceptance
         continue-on-error: true
@@ -83,7 +81,6 @@ jobs:
             -w /app/tests/acceptance \
             "mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble" \
             npx "$ATS_CMD" test --project=Visual --workers=1 "$UPDATE_SNAPSHOTS" "$FILTER"
-      
       - name: Upload visual test results
         if: always()
         continue-on-error: true


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently, if you manually ran the `visual-tests-docker.yml` workflow and only checked `update snapshots` with no grep input, it will throw this error:

`error: option '-u, --update-snapshots [mode]' argument '' is invalid. Allowed choices are all, changed, missing, none. `
<img width="1490" height="358" alt="Screenshot 2026-07-31 at 13 01 48" src="https://github.com/user-attachments/assets/1b21fe4a-8e13-480c-8218-9c5e2554c406" />

### 2. What does this change do, exactly?

Explicitly sets `all` or `none` modes for `--update-snapshots`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
