### PR TITLE
fix: check for valid mainVariantId in product detail route

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -46,6 +46,10 @@ The new privileges are part of the existing "Plugin maintain" (`system:app:chang
 
 ## Core
 
+### Product detail requests ignore deleted configured main variants
+
+Product detail requests no longer fail when a product's variant listing configuration references a deleted main variant. Shopware now ignores the outdated reference and loads the requested product instead. No action is required.
+
 ### Media path cache busting is configurable
 
 The new `shopware.cdn.path_cache_buster` setting defaults to `true`, preserving timestamped media paths. Set it to `false` to keep paths stable for future media uploads and replacements while retaining `?ts=` query-string cache busting. Configure the CDN to include query strings in its cache key. Existing media paths are not migrated.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -46,10 +46,6 @@ The new privileges are part of the existing "Plugin maintain" (`system:app:chang
 
 ## Core
 
-### Product detail requests ignore deleted configured main variants
-
-Product detail requests no longer fail when a product's variant listing configuration references a deleted main variant. Shopware now ignores the outdated reference and loads the requested product instead. No action is required.
-
 ### Media path cache busting is configurable
 
 The new `shopware.cdn.path_cache_buster` setting defaults to `true`, preserving timestamped media paths. Set it to `false` to keep paths stable for future media uploads and replacements while retaining `?ts=` query-string cache busting. Configure the CDN to include query strings in its cache key. Existing media paths are not migrated.

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -264,10 +264,29 @@ class ProductDetailRoute extends AbstractProductDetailRoute
                 || isset($variantListingConfig['mainVariantId'])
             ) {
                 $mainVariantId = $variantListingConfig['mainVariantId'] ?? null;
+
+                if (\is_string($mainVariantId) && Uuid::isValid($mainVariantId) && !$this->mainVariantExists($mainVariantId, $context)) {
+                    $mainVariantId = null;
+                }
             }
         }
 
         return [$mainVariantId, $productData['parentId'] ?? $productId];
+    }
+
+    private function mainVariantExists(string $mainVariantId, SalesChannelContext $context): bool
+    {
+        return $this->connection->fetchOne(
+            '# product-detail-route::main-variant-exists
+            SELECT 1
+            FROM product
+            WHERE id = :id
+            AND version_id = :versionId',
+            [
+                'id' => Uuid::fromHexToBytes($mainVariantId),
+                'versionId' => Uuid::fromHexToBytes($context->getVersionId()),
+            ]
+        ) !== false;
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -124,6 +124,12 @@ class ProductDetailRoute extends AbstractProductDetailRoute
             $loadCmsPage = !$request->query->getBoolean(self::SKIP_CMS_PAGE);
             $product = $this->productRepository->search($criteria, $context)->getEntities()->first();
 
+            if (!$product instanceof SalesChannelProductEntity && $mainVariantId !== null && $this->isParentProductRequest($requestedProductId, $parentProductId)) {
+                $productId = $this->findBestVariant($requestedProductId, $context);
+                $criteria->setIds([$productId]);
+                $product = $this->productRepository->search($criteria, $context)->getEntities()->first();
+            }
+
             if (!$product instanceof SalesChannelProductEntity) {
                 throw ProductException::productNotFound($productId);
             }
@@ -264,29 +270,10 @@ class ProductDetailRoute extends AbstractProductDetailRoute
                 || isset($variantListingConfig['mainVariantId'])
             ) {
                 $mainVariantId = $variantListingConfig['mainVariantId'] ?? null;
-
-                if (\is_string($mainVariantId) && Uuid::isValid($mainVariantId) && !$this->mainVariantExists($mainVariantId, $context)) {
-                    $mainVariantId = null;
-                }
             }
         }
 
         return [$mainVariantId, $productData['parentId'] ?? $productId];
-    }
-
-    private function mainVariantExists(string $mainVariantId, SalesChannelContext $context): bool
-    {
-        return $this->connection->fetchOne(
-            '# product-detail-route::main-variant-exists
-            SELECT 1
-            FROM product
-            WHERE id = :id
-            AND version_id = :versionId',
-            [
-                'id' => Uuid::fromHexToBytes($mainVariantId),
-                'versionId' => Uuid::fromHexToBytes($context->getVersionId()),
-            ]
-        ) !== false;
     }
 
     /**

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -315,6 +315,50 @@ class ProductDetailRouteTest extends TestCase
         static::assertTrue($result->getProduct()->getAvailable());
     }
 
+    public function testLoadIgnoresOrphanedMainVariantFromVariantListingConfig(): void
+    {
+        $productId = Uuid::randomHex();
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn([
+                'variantListingConfig' => '{"displayParent": false, "mainVariantId": "' . Uuid::randomHex() . '"}',
+                'parentId' => null,
+            ]);
+        $connection->expects($this->once())
+            ->method('fetchOne')
+            ->willReturn(false);
+
+        $productEntity = new SalesChannelProductEntity();
+        $productEntity->setId($productId);
+        $productEntity->setCmsPageId('4');
+        $productEntity->setUniqueIdentifier('requested-product');
+        $productEntity->setAvailable(true);
+        $productRepository = $this->createMock(SalesChannelRepository::class);
+        $productRepository->expects($this->once())
+            ->method('search')
+            ->with(static::callback(static function (Criteria $criteria) use ($productId): bool {
+                static::assertSame([$productId], $criteria->getIds());
+
+                return true;
+            }))
+            ->willReturn(
+                new EntitySearchResult(
+                    'product',
+                    1,
+                    new ProductCollection([$productEntity]),
+                    null,
+                    new Criteria(),
+                    $this->context->getContext()
+                )
+            );
+
+        $result = $this->buildRoute($productRepository, $connection)->load($productId, new Request(), $this->context, new Criteria());
+
+        static::assertSame('requested-product', $result->getProduct()->getUniqueIdentifier());
+    }
+
     public function testResolveVariantIdFromEvent(): void
     {
         $connection = $this->createMock(Connection::class);

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -315,35 +315,57 @@ class ProductDetailRouteTest extends TestCase
         static::assertTrue($result->getProduct()->getAvailable());
     }
 
-    public function testLoadIgnoresOrphanedMainVariantFromVariantListingConfig(): void
+    public function testLoadFallsBackToBestVariantWhenConfiguredMainVariantIsNotAvailable(): void
     {
         $productId = Uuid::randomHex();
+        $mainVariantId = Uuid::randomHex();
+        $bestVariantId = Uuid::randomHex();
         $connection = $this->createMock(Connection::class);
         $connection
             ->expects($this->once())
             ->method('fetchAssociative')
             ->willReturn([
-                'variantListingConfig' => '{"displayParent": false, "mainVariantId": "' . Uuid::randomHex() . '"}',
+                'variantListingConfig' => '{"displayParent": false, "mainVariantId": "' . $mainVariantId . '"}',
                 'parentId' => null,
             ]);
-        $connection->expects($this->once())
-            ->method('fetchOne')
-            ->willReturn(false);
 
         $productEntity = new SalesChannelProductEntity();
-        $productEntity->setId($productId);
+        $productEntity->setId($bestVariantId);
         $productEntity->setCmsPageId('4');
-        $productEntity->setUniqueIdentifier('requested-product');
+        $productEntity->setUniqueIdentifier('best-variant');
         $productEntity->setAvailable(true);
         $productRepository = $this->createMock(SalesChannelRepository::class);
         $productRepository->expects($this->once())
+            ->method('searchIds')
+            ->willReturn(new IdSearchResult(
+                1,
+                [
+                    $bestVariantId => [
+                        'primaryKey' => $bestVariantId,
+                        'data' => [],
+                    ],
+                ],
+                new Criteria(),
+                $this->context->getContext()
+            ));
+        $searchCall = 0;
+        $productRepository->expects($this->exactly(2))
             ->method('search')
-            ->with(static::callback(static function (Criteria $criteria) use ($productId): bool {
-                static::assertSame([$productId], $criteria->getIds());
+            ->with(static::callback(function (Criteria $criteria) use (&$searchCall, $mainVariantId, $bestVariantId): bool {
+                ++$searchCall;
+                static::assertSame($searchCall === 1 ? [$mainVariantId] : [$bestVariantId], $criteria->getIds());
 
                 return true;
             }))
-            ->willReturn(
+            ->willReturnOnConsecutiveCalls(
+                new EntitySearchResult(
+                    'product',
+                    0,
+                    new ProductCollection(),
+                    null,
+                    new Criteria(),
+                    $this->context->getContext()
+                ),
                 new EntitySearchResult(
                     'product',
                     1,
@@ -356,7 +378,7 @@ class ProductDetailRouteTest extends TestCase
 
         $result = $this->buildRoute($productRepository, $connection)->load($productId, new Request(), $this->context, new Criteria());
 
-        static::assertSame('requested-product', $result->getProduct()->getUniqueIdentifier());
+        static::assertSame('best-variant', $result->getProduct()->getUniqueIdentifier());
     }
 
     public function testResolveVariantIdFromEvent(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Product Detail Route can sometimes not resolve mainVariantID resulting in a 404 for a valid product

### 2. What does this change do, exactly?

fixed by explicitly checking for a valid mainVariantId and ensuring it exists in the context before using it. This prevents potential issues with invalid or non-existent variant IDs.

### 3. Describe each step to reproduce the issue or behaviour.

In Admin: Create product in admin, make it visible in storefront category & sales channel
In Admin: Add 2 variants to it
In Admin: Select 1 of the variants as main variant
In Admin: Delete all variants
In Storefront: Try to click on product in category view.
In Storefront: 404 error because the configured variant_listing_config still has the mainVariantId configured that no longer exists.

### 4. Please link to the relevant issues (if any).

- fixes https://github.com/shopware/shopware/issues/18362
- relates https://github.com/shopware/shopware/issues/4373
- relates https://github.com/shopware/shopware/issues/4887

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
