### PR TITLE
fix: open selected domain path in HMR watcher

### DIFF
--- a/src/Storefront/Resources/app/storefront/build/hmr-browser-url.js
+++ b/src/Storefront/Resources/app/storefront/build/hmr-browser-url.js
@@ -1,0 +1,18 @@
+/**
+ * @sw-package framework
+ * @deprecated tag:v6.8.0 - The HMR mode will be removed.
+ */
+
+/**
+ * @param {URL} proxyUrl
+ * @param {URL} domainUrl
+ * @returns {string}
+ */
+function getBrowserUrl(proxyUrl, domainUrl) {
+    const browserUrl = new URL(proxyUrl.origin);
+    browserUrl.pathname = domainUrl.pathname;
+
+    return browserUrl.toString();
+}
+
+module.exports = getBrowserUrl;

--- a/src/Storefront/Resources/app/storefront/build/start-hot-reload.js
+++ b/src/Storefront/Resources/app/storefront/build/start-hot-reload.js
@@ -11,6 +11,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { spawn } = require('node:child_process');
 const createLiveReloadServer = require('./live-reload-server/index');
+const getBrowserUrl = require('./hmr-browser-url');
 
 const proxyPort = Number(process.env.STOREFRONT_PROXY_PORT) || 9998;
 const assetPort = Number(process.env.STOREFRONT_ASSETS_PORT) || 9999;
@@ -209,7 +210,7 @@ server.then(() => {
     }
 
     if (!fs.existsSync('/.dockerenv')) {
-        openBrowserWithUrl(`${proxyUrlEnv.origin}`);
+        openBrowserWithUrl(getBrowserUrl(proxyUrlEnv, domainUrl));
     }
 
     // The "Watcher is running" message is printed by the webpack "done" hook in webpack.config.js

--- a/src/Storefront/Resources/app/storefront/test/build/hmr-browser-url.test.js
+++ b/src/Storefront/Resources/app/storefront/test/build/hmr-browser-url.test.js
@@ -1,0 +1,24 @@
+const getBrowserUrl = require('../../build/hmr-browser-url');
+
+/**
+ * @sw-package framework
+ */
+describe('hmr-browser-url', () => {
+    test('uses the selected sales channel path with the proxy origin', () => {
+        const browserUrl = getBrowserUrl(
+            new URL('http://127.0.0.1:9998'),
+            new URL('http://127.0.0.1:8022/de'),
+        );
+
+        expect(browserUrl).toBe('http://127.0.0.1:9998/de');
+    });
+
+    test('uses the proxy root when the selected sales channel has no path', () => {
+        const browserUrl = getBrowserUrl(
+            new URL('http://127.0.0.1:9998'),
+            new URL('http://127.0.0.1:8022'),
+        );
+
+        expect(browserUrl).toBe('http://127.0.0.1:9998/');
+    });
+});


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

When the legacy Storefront HMR watcher is run outside Docker, it opens the proxy origin but drops the path of the selected sales-channel domain. Selecting /de, for example, opens the proxy root instead.

### 2. What does this change do, exactly?

Preserves the selected sales-channel pathname when opening the HMR proxy URL.

The Vite-based `composer storefront:dev-server` workflow does not open a browser automatically, so this issue is limited to the deprecated HMR watcher.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure a sales-channel domain with a path, such as http://127.0.0.1:8022/de.
2. Run composer watch:storefront outside Docker.
3. Select that domain.
4. Before: the browser opens http://127.0.0.1:9998.
5. After: the browser opens http://127.0.0.1:9998/de.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #6287 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
