### PR TITLE
fix: make EnvTestBehaviour genuinely unset environment variables

### DIFF
--- a/src/Core/Framework/Test/TestCaseBase/EnvTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/EnvTestBehaviour.php
@@ -3,7 +3,9 @@
 namespace Shopware\Core\Framework\Test\TestCaseBase;
 
 use PHPUnit\Framework\Attributes\After;
+use Shopware\Core\Framework\Log\Package;
 
+#[Package('framework')]
 trait EnvTestBehaviour
 {
     /**
@@ -12,6 +14,8 @@ trait EnvTestBehaviour
     private array $originalEnvVars = [];
 
     /**
+     * A null value removes the variable for the duration of the test.
+     *
      * @param array<string, string|int|bool|null> $envVars
      */
     public function setEnvVars(array $envVars): void
@@ -20,23 +24,35 @@ trait EnvTestBehaviour
             if (!\array_key_exists($envVar, $this->originalEnvVars)) {
                 $this->originalEnvVars[$envVar] = $_SERVER[$envVar] ?? null;
             }
-            $_SERVER[$envVar] = $value;
-            $_ENV[$envVar] = $value;
-            putenv("{$envVar}={$value}");
+
+            $this->applyEnvVar($envVar, $value);
         }
     }
 
     #[After]
     public function resetEnvVars(): void
     {
-        if ($this->originalEnvVars) {
-            foreach ($this->originalEnvVars as $envVar => $value) {
-                $_SERVER[$envVar] = $value;
-                $_ENV[$envVar] = $value;
-                putenv("{$envVar}={$value}");
-            }
-
-            $this->originalEnvVars = [];
+        foreach ($this->originalEnvVars as $envVar => $value) {
+            $this->applyEnvVar($envVar, $value);
         }
+
+        $this->originalEnvVars = [];
+    }
+
+    private function applyEnvVar(string $envVar, string|int|bool|null $value): void
+    {
+        if ($value === null) {
+            // putenv("NAME=") would not remove the variable but set it to an empty string
+            // in the real environment, where spawned processes (e.g. RunInSeparateProcess
+            // children) would still see it
+            unset($_SERVER[$envVar], $_ENV[$envVar]);
+            putenv($envVar);
+
+            return;
+        }
+
+        $_SERVER[$envVar] = $value;
+        $_ENV[$envVar] = $value;
+        putenv("{$envVar}={$value}");
     }
 }

--- a/tests/unit/Core/Framework/Test/TestCaseBase/EnvTestBehaviourTest.php
+++ b/tests/unit/Core/Framework/Test/TestCaseBase/EnvTestBehaviourTest.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Test\TestCaseBase;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(EnvTestBehaviour::class)]
+class EnvTestBehaviourTest extends TestCase
+{
+    use EnvTestBehaviour;
+
+    private const PREVIOUSLY_UNSET = 'ENV_TEST_BEHAVIOUR_TEST_PREVIOUSLY_UNSET';
+
+    private const PREVIOUSLY_SET = 'ENV_TEST_BEHAVIOUR_TEST_PREVIOUSLY_SET';
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER[self::PREVIOUSLY_UNSET], $_ENV[self::PREVIOUSLY_UNSET]);
+        unset($_SERVER[self::PREVIOUSLY_SET], $_ENV[self::PREVIOUSLY_SET]);
+        putenv(self::PREVIOUSLY_UNSET);
+        putenv(self::PREVIOUSLY_SET);
+    }
+
+    public function testResetRemovesAVariableThatWasUnsetBefore(): void
+    {
+        static::assertFalse(getenv(self::PREVIOUSLY_UNSET));
+
+        $this->setEnvVars([self::PREVIOUSLY_UNSET => 'redirected']);
+
+        static::assertSame('redirected', getenv(self::PREVIOUSLY_UNSET));
+        static::assertSame('redirected', $_SERVER[self::PREVIOUSLY_UNSET]);
+        static::assertSame('redirected', $_ENV[self::PREVIOUSLY_UNSET]);
+
+        $this->resetEnvVars();
+
+        // getenv() reads the real process environment, which spawned processes inherit;
+        // "" instead of false here means the variable would leak into them
+        static::assertFalse(getenv(self::PREVIOUSLY_UNSET));
+        static::assertArrayNotHasKey(self::PREVIOUSLY_UNSET, $_SERVER);
+        static::assertArrayNotHasKey(self::PREVIOUSLY_UNSET, $_ENV);
+    }
+
+    public function testResetRestoresAVariableThatWasSetBefore(): void
+    {
+        $original = 'original-' . bin2hex(random_bytes(4));
+        $_SERVER[self::PREVIOUSLY_SET] = $original;
+        $_ENV[self::PREVIOUSLY_SET] = $original;
+        putenv(self::PREVIOUSLY_SET . '=' . $original);
+
+        $this->setEnvVars([self::PREVIOUSLY_SET => 'redirected']);
+
+        static::assertSame('redirected', getenv(self::PREVIOUSLY_SET));
+
+        $this->resetEnvVars();
+
+        static::assertSame($original, getenv(self::PREVIOUSLY_SET));
+        static::assertSame($original, $_SERVER[self::PREVIOUSLY_SET]);
+        static::assertSame($original, $_ENV[self::PREVIOUSLY_SET]);
+    }
+
+    public function testNullValueRemovesTheVariableForTheDurationOfTheTest(): void
+    {
+        $original = 'original-' . bin2hex(random_bytes(4));
+        $_SERVER[self::PREVIOUSLY_SET] = $original;
+        $_ENV[self::PREVIOUSLY_SET] = $original;
+        putenv(self::PREVIOUSLY_SET . '=' . $original);
+
+        $this->setEnvVars([self::PREVIOUSLY_SET => null]);
+
+        static::assertFalse(getenv(self::PREVIOUSLY_SET));
+        static::assertArrayNotHasKey(self::PREVIOUSLY_SET, $_SERVER);
+        static::assertArrayNotHasKey(self::PREVIOUSLY_SET, $_ENV);
+
+        $this->resetEnvVars();
+
+        static::assertSame($original, getenv(self::PREVIOUSLY_SET));
+        static::assertSame($original, $_SERVER[self::PREVIOUSLY_SET]);
+    }
+
+    public function testSetEnvVarsKeepsTheOriginalValueAcrossRepeatedCalls(): void
+    {
+        $_SERVER[self::PREVIOUSLY_SET] = 'original';
+        $_ENV[self::PREVIOUSLY_SET] = 'original';
+        putenv(self::PREVIOUSLY_SET . '=original');
+
+        $this->setEnvVars([self::PREVIOUSLY_SET => 'first']);
+        $this->setEnvVars([self::PREVIOUSLY_SET => 'second']);
+
+        $this->resetEnvVars();
+
+        static::assertSame('original', getenv(self::PREVIOUSLY_SET));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`EnvTestBehaviour::resetEnvVars()` cannot restore a variable that was unset before the test: the stored `null` original is written back as `putenv("NAME=")`, which sets the variable to an empty string in the real process environment instead of removing it. Later `#[RunInSeparateProcess]` children inherit that empty value; with `APP_CACHE_DIR` this makes their kernel boot fatal (cache root at the filesystem root), which is what fails the nightly update and blue-green jobs depending on the random test order.

### 2. What does this change do, exactly?

- `resetEnvVars()` now genuinely removes variables whose original was `null`: `putenv($name)` plus `unset($_SERVER[$name], $_ENV[$name])`. Non-null originals are restored as before.
- `setEnvVars()` applies the same semantics to a `null` value, so `setEnvVars(['APP_URL' => null])` removes the variable for the duration of the test instead of leaving `APP_URL=""` in the real environment. The five existing callers that pass `null` already expect exactly this.
- Adds a unit test covering unset-restore, set-restore, null-removal, and original preservation across repeated `setEnvVars()` calls.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run a phpunit suite that executes `tests/integration/Core/KernelTest.php` (a `setEnvVars(['APP_CACHE_DIR' => ...])` user) before `tests/integration/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php`.
2. Without this fix, `testManagedByComposerIsSkipped` dies in its separate process: `Unable to create the "cache" directory (/var/cache/test_...)`.
3. With this fix, the same ordered suite passes (verified locally in Docker).

On CI proven with 
https://github.com/shopware/shopware/actions/runs/30631987259/job/91160360796?pr=18886 from live demo PR https://github.com/shopware/shopware/pull/18886

### 4. Please link to the relevant issues (if any).

- resolves #18882

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
