### PR TITLE
ci: demo the 2026-07-31 nightly failure with pinned random-order seed

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -221,28 +221,28 @@ jobs:
       - name: Start Webserver
         run: symfony server:start -d
 
+      # DEMO (do not merge): the nightly-profile steps run unconditionally and phpunit is
+      # pinned to the random-order seed of the failing 2026-07-31 nightly, so this PR
+      # reproduces that run's test order deterministically.
       - name: Install Shopware in previous major version on test DB
-        if: inputs.profile == 'nightly'
         run: composer init:testdb
 
       - name: Run next major migrations on test DB
-        if: inputs.profile == 'nightly'
         run: DATABASE_URL="mysql://root@127.0.0.1:3306/shopware_test" bin/console database:migrate --all core.V6_8
 
       - name: Run integration tests
-        if: inputs.profile == 'nightly'
-        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure
+        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure --random-order-seed 1785462005
 
       - name: Install Shopware in previous major version
-        if: inputs.profile != 'nightly'
+        if: inputs.profile == 'demo-disabled'
         run: bin/console system:install --basic-setup --create-database --skip-assets-install
 
       - name: Run next major migrations
-        if: inputs.profile != 'nightly'
+        if: inputs.profile == 'demo-disabled'
         run: bin/console database:migrate --all core.V6_8
 
       - name: Run blue-green check
-        if: inputs.profile != 'nightly'
+        if: inputs.profile == 'demo-disabled'
         run: php .github/bin/blue-green-check.php
 
   blue-green-66-67:

--- a/src/Core/Framework/Test/TestCaseBase/EnvTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/EnvTestBehaviour.php
@@ -3,7 +3,9 @@
 namespace Shopware\Core\Framework\Test\TestCaseBase;
 
 use PHPUnit\Framework\Attributes\After;
+use Shopware\Core\Framework\Log\Package;
 
+#[Package('framework')]
 trait EnvTestBehaviour
 {
     /**
@@ -12,6 +14,8 @@ trait EnvTestBehaviour
     private array $originalEnvVars = [];
 
     /**
+     * A null value removes the variable for the duration of the test.
+     *
      * @param array<string, string|int|bool|null> $envVars
      */
     public function setEnvVars(array $envVars): void
@@ -20,23 +24,35 @@ trait EnvTestBehaviour
             if (!\array_key_exists($envVar, $this->originalEnvVars)) {
                 $this->originalEnvVars[$envVar] = $_SERVER[$envVar] ?? null;
             }
-            $_SERVER[$envVar] = $value;
-            $_ENV[$envVar] = $value;
-            putenv("{$envVar}={$value}");
+
+            $this->applyEnvVar($envVar, $value);
         }
     }
 
     #[After]
     public function resetEnvVars(): void
     {
-        if ($this->originalEnvVars) {
-            foreach ($this->originalEnvVars as $envVar => $value) {
-                $_SERVER[$envVar] = $value;
-                $_ENV[$envVar] = $value;
-                putenv("{$envVar}={$value}");
-            }
-
-            $this->originalEnvVars = [];
+        foreach ($this->originalEnvVars as $envVar => $value) {
+            $this->applyEnvVar($envVar, $value);
         }
+
+        $this->originalEnvVars = [];
+    }
+
+    private function applyEnvVar(string $envVar, string|int|bool|null $value): void
+    {
+        if ($value === null) {
+            // putenv("NAME=") would not remove the variable but set it to an empty string
+            // in the real environment, where spawned processes (e.g. RunInSeparateProcess
+            // children) would still see it
+            unset($_SERVER[$envVar], $_ENV[$envVar]);
+            putenv($envVar);
+
+            return;
+        }
+
+        $_SERVER[$envVar] = $value;
+        $_ENV[$envVar] = $value;
+        putenv("{$envVar}={$value}");
     }
 }

--- a/tests/unit/Core/Framework/Test/TestCaseBase/EnvTestBehaviourTest.php
+++ b/tests/unit/Core/Framework/Test/TestCaseBase/EnvTestBehaviourTest.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Test\TestCaseBase;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(EnvTestBehaviour::class)]
+class EnvTestBehaviourTest extends TestCase
+{
+    use EnvTestBehaviour;
+
+    private const PREVIOUSLY_UNSET = 'ENV_TEST_BEHAVIOUR_TEST_PREVIOUSLY_UNSET';
+
+    private const PREVIOUSLY_SET = 'ENV_TEST_BEHAVIOUR_TEST_PREVIOUSLY_SET';
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER[self::PREVIOUSLY_UNSET], $_ENV[self::PREVIOUSLY_UNSET]);
+        unset($_SERVER[self::PREVIOUSLY_SET], $_ENV[self::PREVIOUSLY_SET]);
+        putenv(self::PREVIOUSLY_UNSET);
+        putenv(self::PREVIOUSLY_SET);
+    }
+
+    public function testResetRemovesAVariableThatWasUnsetBefore(): void
+    {
+        static::assertFalse(getenv(self::PREVIOUSLY_UNSET));
+
+        $this->setEnvVars([self::PREVIOUSLY_UNSET => 'redirected']);
+
+        static::assertSame('redirected', getenv(self::PREVIOUSLY_UNSET));
+        static::assertSame('redirected', $_SERVER[self::PREVIOUSLY_UNSET]);
+        static::assertSame('redirected', $_ENV[self::PREVIOUSLY_UNSET]);
+
+        $this->resetEnvVars();
+
+        // getenv() reads the real process environment, which spawned processes inherit;
+        // "" instead of false here means the variable would leak into them
+        static::assertFalse(getenv(self::PREVIOUSLY_UNSET));
+        static::assertArrayNotHasKey(self::PREVIOUSLY_UNSET, $_SERVER);
+        static::assertArrayNotHasKey(self::PREVIOUSLY_UNSET, $_ENV);
+    }
+
+    public function testResetRestoresAVariableThatWasSetBefore(): void
+    {
+        $original = 'original-' . bin2hex(random_bytes(4));
+        $_SERVER[self::PREVIOUSLY_SET] = $original;
+        $_ENV[self::PREVIOUSLY_SET] = $original;
+        putenv(self::PREVIOUSLY_SET . '=' . $original);
+
+        $this->setEnvVars([self::PREVIOUSLY_SET => 'redirected']);
+
+        static::assertSame('redirected', getenv(self::PREVIOUSLY_SET));
+
+        $this->resetEnvVars();
+
+        static::assertSame($original, getenv(self::PREVIOUSLY_SET));
+        static::assertSame($original, $_SERVER[self::PREVIOUSLY_SET]);
+        static::assertSame($original, $_ENV[self::PREVIOUSLY_SET]);
+    }
+
+    public function testNullValueRemovesTheVariableForTheDurationOfTheTest(): void
+    {
+        $original = 'original-' . bin2hex(random_bytes(4));
+        $_SERVER[self::PREVIOUSLY_SET] = $original;
+        $_ENV[self::PREVIOUSLY_SET] = $original;
+        putenv(self::PREVIOUSLY_SET . '=' . $original);
+
+        $this->setEnvVars([self::PREVIOUSLY_SET => null]);
+
+        static::assertFalse(getenv(self::PREVIOUSLY_SET));
+        static::assertArrayNotHasKey(self::PREVIOUSLY_SET, $_SERVER);
+        static::assertArrayNotHasKey(self::PREVIOUSLY_SET, $_ENV);
+
+        $this->resetEnvVars();
+
+        static::assertSame($original, getenv(self::PREVIOUSLY_SET));
+        static::assertSame($original, $_SERVER[self::PREVIOUSLY_SET]);
+    }
+
+    public function testSetEnvVarsKeepsTheOriginalValueAcrossRepeatedCalls(): void
+    {
+        $_SERVER[self::PREVIOUSLY_SET] = 'original';
+        $_ENV[self::PREVIOUSLY_SET] = 'original';
+        putenv(self::PREVIOUSLY_SET . '=original');
+
+        $this->setEnvVars([self::PREVIOUSLY_SET => 'first']);
+        $this->setEnvVars([self::PREVIOUSLY_SET => 'second']);
+
+        $this->resetEnvVars();
+
+        static::assertSame('original', getenv(self::PREVIOUSLY_SET));
+    }
+}


### PR DESCRIPTION
**DO NOT MERGE.** CI-only demonstration that #18884 fixes the order-dependent nightly failure under the exact failing conditions.

### 1. Why is this change necessary?

The failure in the nightly [PHP blue green 6.7 -> 6.8 -> 6.7](https://github.com/shopware/shopware/actions/runs/30596849358/job/91051010035) job depends on the per-run random test order. This PR pins that run's seed and commit so the scenario replays deterministically, and carries the #18884 fix on top to show the same seeded run passing.

### 2. What does this change do, exactly?

- Branches from the exact trunk commit the failing nightly ran on (`8ae7f143588`), with the PR base pinned to the same commit, so the seeded shuffle reproduces the identical test order (order depends on both seed and test set; PR CI runs the merge ref).
- In the `blue-green-67-68` job, runs the nightly-profile steps unconditionally and appends `--random-order-seed 1785462005` (the failing run's seed) to the phpunit invocation.
- Cherry-picks the #18884 fix. It changes no integration test, so the seeded order is unchanged.

Result:

- Control (workflow change only, without the fix): the job [fails byte-for-byte like the nightly](https://github.com/shopware/shopware/actions/runs/30631097960/job/91157423665), down to identical totals (`Tests: 2806, Assertions: 25594, Errors: 1`).
- With the fix cherry-picked: the same seeded job passes.

### 3. Describe each step to reproduce the issue or behaviour.

Covered by section 2; the PR's check history is the demonstration.

### 4. Please link to the relevant issues (if any).

- relates #18884

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
