### PR TITLE
fix: duplicates block when dragging across sections

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
@@ -439,37 +439,18 @@ export default Shopware.Component.wrapComponentConfig({
             if (this.currentDragSectionIndex !== dropSectionIndex && !dropSectionHasBlock) {
                 dragData.block.isDragging = true;
 
-                // calculate the remove index (this may differ since the block is moved each time it enters a new
-                // section while the dragSectionIndex is the static start index of the drag
-                let removeIndex = dragSectionIndex;
-                if (
-                    this.currentDragSectionIndex !== dragSectionIndex &&
-                    Math.abs(this.currentDragSectionIndex - dropSectionIndex) === 1
-                ) {
-                    removeIndex = this.currentDragSectionIndex;
-                }
-
-                // drag direction is upwards so the currentDragSectionIndex is incremented
-                if (this.currentDragSectionIndex - dropSectionIndex < 0) {
-                    this.currentDragSectionIndex += 1;
-                }
-
-                // drag direction is downwards so the currentDragSectionIndex is decremented
-                if (this.currentDragSectionIndex - dropSectionIndex > 0) {
-                    this.currentDragSectionIndex -= 1;
-                }
+                const oldSection = this.page.sections![this.currentDragSectionIndex];
 
                 dragData.block.sectionId = dropSection.id;
 
                 dropSection.blocks!.add(dragData.block);
-
-                const oldSection = this.page.sections![removeIndex];
 
                 oldSection.blocks!.remove(dragData.block.id);
                 oldSection._origin.blocks!.remove(dragData.block.id);
 
                 this.refreshPosition(oldSection.blocks!);
                 this.refreshPosition(dropSection.blocks!);
+                this.currentDragSectionIndex = dropSectionIndex;
                 return;
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
@@ -555,6 +555,53 @@ describe('module/sw-cms/component/sw-cms-sidebar', () => {
         expect(blockDrag.block.sectionId).toBe('2222');
     });
 
+    it('should not duplicate a block when dragging across multiple sections', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.page.sections.push(
+            new Entity('3333', 'section', {
+                type: 'sidebar',
+                blocks: getBlockCollection([]),
+            }),
+            new Entity('4444', 'section', {
+                type: 'sidebar',
+                blocks: getBlockCollection([]),
+            }),
+            new Entity('5555', 'section', {
+                type: 'sidebar',
+                blocks: getBlockCollection([]),
+            }),
+        );
+
+        const blockDrag = {
+            block: getBlockData(0, '1a2b'),
+            sectionIndex: 0,
+        };
+
+        wrapper.vm.onBlockDragSort(
+            blockDrag,
+            {
+                block: getBlockData(0, 'drop-target-1'),
+                sectionIndex: 2,
+            },
+            true,
+        );
+        wrapper.vm.onBlockDragSort(
+            blockDrag,
+            {
+                block: getBlockData(0, 'drop-target-2'),
+                sectionIndex: 4,
+            },
+            true,
+        );
+
+        const sections = wrapper.vm.page.sections;
+        const sectionsContainingBlock = sections.filter((section) => section.blocks.has('1a2b'));
+
+        expect(sectionsContainingBlock).toHaveLength(1);
+        expect(sectionsContainingBlock[0].id).toBe('5555');
+    });
+
     it('should stop prompting a warning when entering the navigator, when "Do not remind me" option has been checked once', async () => {
         const wrapper = await createWrapper();
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Dragging a CMS block quickly across multiple sections can leave duplicate block entries and place the block in an intermediate section instead of the intended target.

### 2. What does this change do, exactly?

The drag handler now removes the block from the section that currently contains it and updates the tracked current section after every move.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a layout in Shopping Experiences with several sections.
2. Add blocks to the sections.
3. Drag a block quickly across multiple sections in the Navigator (sidebar).
4. Observe that the block may be duplicated or remain in an intermediate section.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #12001

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
