### PR TITLE
fix: trigger cache refresh on PaaS instances in acceptance tests

### DIFF
--- a/tests/acceptance/tasks/ShopCustomer/Listing/CheckVisibilityInHome.ts
+++ b/tests/acceptance/tasks/ShopCustomer/Listing/CheckVisibilityInHome.ts
@@ -36,11 +36,11 @@ export const CheckVisibilityInHome = base.extend<{ CheckVisibilityInHome: Task }
                 const productLocators = await StorefrontHome.getListingItemByProductName(productName);
 
                 // The homepage listing can lag behind the Store API, so render it with a
-                // cache busting parameter until the product shows up. On SaaS the listing is
-                // OpenSearch-backed and only reflects new products after an index refresh,
-                // which is triggered by the delayed cache clear.
+                // cache busting parameter until the product shows up. On hosted instances
+                // (SaaS and PaaS) the listing is OpenSearch-backed and only reflects new
+                // products after an index refresh, triggered by the delayed cache clear.
                 await ShopCustomer.expects(async () => {
-                    if (InstanceMeta.isSaaS) {
+                    if (InstanceMeta.isSaaS || InstanceMeta.isPaaS) {
                         await TestDataService.clearCaches();
                     }
                     await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);

--- a/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
+++ b/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
@@ -36,7 +36,7 @@ test('Category Lighthouse Report', async ({
     await ShopCustomer.goesTo(StorefrontCategory.url(category.name));
 
     await ShopCustomer.expects(async () => {
-        if (InstanceMeta.isSaaS) {
+        if (InstanceMeta.isSaaS || InstanceMeta.isPaaS) {
             await TestDataService.clearCaches();
         }
         await ShopCustomer.goesTo(`${StorefrontCategory.url(category.name)}?a=${Date.now()}`);

--- a/tests/acceptance/tests/Product/ProductFilter.spec.ts
+++ b/tests/acceptance/tests/Product/ProductFilter.spec.ts
@@ -79,7 +79,7 @@ test(
 
         await test.step('Verify setup filters display & enabled', async () => {
             await ShopCustomer.expects(async () => {
-                if (InstanceMeta.isSaaS) {
+                if (InstanceMeta.isSaaS || InstanceMeta.isPaaS) {
                     await TestDataService.clearCaches();
                 }
                 await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
@@ -138,7 +138,7 @@ test(
             await ShopCustomer.expects(StorefrontHome.loader).not.toBeAttached();
 
             await ShopCustomer.expects(async () => {
-                if (InstanceMeta.isSaaS) {
+                if (InstanceMeta.isSaaS || InstanceMeta.isPaaS) {
                     await TestDataService.clearCaches();
                 }
                 await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
@@ -228,7 +228,7 @@ test(
             await ShopCustomer.expects(StorefrontHome.loader).not.toBeAttached();
 
             await ShopCustomer.expects(async () => {
-                if (InstanceMeta.isSaaS) {
+                if (InstanceMeta.isSaaS || InstanceMeta.isPaaS) {
                     await TestDataService.clearCaches();
                 }
                 await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
@@ -324,7 +324,7 @@ test(
 
         await test.step('Verify setup filters display', async () => {
             await ShopCustomer.expects(async () => {
-                if (InstanceMeta.isSaaS) {
+                if (InstanceMeta.isSaaS || InstanceMeta.isPaaS) {
                     await TestDataService.clearCaches();
                 }
                 await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);

--- a/tests/acceptance/tests/Product/ProductImagesInTheStorefront.spec.ts
+++ b/tests/acceptance/tests/Product/ProductImagesInTheStorefront.spec.ts
@@ -42,7 +42,7 @@ test(
 
         await test.step('Logged-In shop customer should be able to see the cover image on the product listing page.', async () => {
             await ShopCustomer.expects(async () => {
-                if (InstanceMeta.isSaaS) {
+                if (InstanceMeta.isSaaS || InstanceMeta.isPaaS) {
                     await TestDataService.clearCaches();
                 }
                 await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);

--- a/tests/acceptance/tests/Product/ProductReview.spec.ts
+++ b/tests/acceptance/tests/Product/ProductReview.spec.ts
@@ -37,7 +37,7 @@ test(
             description: 'https://github.com/shopware/shopware/issues/13219',
         },
     },
-    async ({ ShopCustomer, TestDataService, StorefrontProductDetail, LoginViaReviewsTab, Logout }) => {
+    async ({ ShopCustomer, TestDataService, StorefrontProductDetail, LoginViaReviewsTab, Logout, InstanceMeta }) => {
         const product = await TestDataService.createBasicProduct();
         const customer = await TestDataService.createCustomer();
 
@@ -60,6 +60,9 @@ test(
             await ShopCustomer.expects(StorefrontProductDetail.reviewLoginForm).toBeVisible();
             await ShopCustomer.expects(StorefrontProductDetail.forgottenPasswordLink).toBeVisible();
             await ShopCustomer.attemptsTo(LoginViaReviewsTab(product, customer));
+            if (InstanceMeta.isSaaS || InstanceMeta.isPaaS) {
+                await TestDataService.clearCaches();
+            }
 
             // collapse depend on page-level initialization (JS event listeners, aria-expanded, etc.) which don’t re-fire after DOM patching.
             await ShopCustomer.presses(StorefrontProductDetail.reviewsTab);

--- a/tests/acceptance/tests/Product/VariantProductListingPriceVisibility.spec.ts
+++ b/tests/acceptance/tests/Product/VariantProductListingPriceVisibility.spec.ts
@@ -65,7 +65,7 @@ test(
 
         await ShopCustomer.expects(async () => {
             await test.step('Wait for products to be visible on storefront.', async () => {
-                if (InstanceMeta.isSaaS) {
+                if (InstanceMeta.isSaaS || InstanceMeta.isPaaS) {
                     await TestDataService.clearCaches();
                 }
                 await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);


### PR DESCRIPTION
### 1. Why is this change necessary?

Since the acceptance-suite performance changes (#18889) landed, the nightly PaaS ATS runs fail: the Wishlist guest test consistently, plus related sporadic failures. The cache clear that keeps storefront listings fresh during visibility checks was gated on `InstanceMeta.isSaaS` — PaaS instances are equally OpenSearch-backed and run with the HTTP cache enabled, but report `isSaaS = false`, so the clear never fired there. Pages cached before the test data existed were served stale, and products never appeared.

CI and local environments were unaffected (they run without the HTTP cache), which is why this only surfaced on PaaS.

### 2. What does this change do, exactly?

Extends the gate to cover both hosted instance types (`isSaaS || isPaaS`) in the storefront visibility checks, and restores the one cache clear in the product review test that had been removed as CI-redundant, under the same gate. Behaviour on CI and local environments is unchanged. PaaS detection relies on `SHOPWARE_ACCEPTANCE_INSTANCE_TYPE=paas`, which the PaaS nightly pipeline already sets.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the acceptance suite against a PaaS instance (`SHOPWARE_ACCEPTANCE_INSTANCE_TYPE=paas`, HTTP cache enabled).
2. Without this change, `WishlistGuestFunctionalities` fails: the homepage is cached during page setup, and the test's later plain-URL navigation serves the stale page without the created products.

### 4. Please link to the relevant issues (if any).

- relates #18889
- Failing runs: https://github.com/shopware-redstone/nightly-paas-ats/actions

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them