### PR TITLE
ci: request codeowner team reviews with an octo-sts token

### DIFF
--- a/.github/workflows/codeowner.yml
+++ b/.github/workflows/codeowner.yml
@@ -12,8 +12,7 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
+  id-token: write
 
 jobs:
   codeowners:
@@ -31,10 +30,20 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: git fetch --no-tags origin "pull/${PR_NUMBER}/head"
 
+      # GITHUB_TOKEN has no organization scope, so requesting a review from a team
+      # fails with "Could not resolve to a node with the global id of 'T_…'". No
+      # fallback on purpose: falling back would silently reintroduce that failure.
+      - name: 'Mint token'
+        id: sts
+        uses: shopware/octo-sts-action@main
+        with:
+          scope: shopware
+          identity: CodeownersPlus
+
       - name: 'Codeowners Plus'
         uses: multimediallc/codeowners-plus@492316f7b626694d8e43813585364ce6fab6d579 # v1.10.0
         with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          github-token: '${{ steps.sts.outputs.token }}'
           pr: '${{ github.event.pull_request.number }}'
           verbose: true
           quiet: ${{ github.event.pull_request.draft }}


### PR DESCRIPTION
### 1. Why is this change necessary?

The `Code Owners` job fails on every PR whose codeowners resolve to a required team: `secrets.GITHUB_TOKEN` has no organization scope, so `codeowners-plus` cannot resolve the team when requesting its review and gets a 422 `Could not resolve to a node with the global id of "T_…"`.

This became reachable with #18785, which added the first blocking owner (`.github/**`, `.gitlab/**` → `@shopware/product-operations`). Every rule before that was optional (`?`), and optional owners are only pinged in a comment.

### 2. What does this change do, exactly?

Mints an octo-sts token with the new `CodeownersPlus` identity (`members: read` plus the write access the action needs) and passes it to the action instead of `GITHUB_TOKEN`. `GITHUB_TOKEN` drops to `contents: read`.

Depends on shopware/.github#110 — that policy has to be merged first, otherwise the minting step fails.

### 3. Describe each step to reproduce the issue or behaviour.

Open a PR that touches `.github/**` and watch the `Code Owners` job, e.g. https://github.com/shopware/shopware/actions/runs/30795921287/job/91629365122.

### 4. Please link to the relevant issues (if any).

relates #18785

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them