### PR TITLE
fix: protect plugin filesystem metadata

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -12,6 +12,7 @@ Three admin endpoints that previously only required authentication now enforce A
 * `GET /api/_action/scheduled-task/min-run-interval` requires the existing `scheduled_task:read` privilege.
 
 Administration users are not affected: both privileges are granted to every authenticated Administration user at runtime, because these endpoints back the admin worker that processes the message queue in every admin session. Integrations and API clients calling these endpoints must have the respective privilege added to their ACL role — the runtime defaults apply to Administration users only. External workers should keep using the `bin/console messenger:consume` and `scheduled-task:run` CLI commands, which are unaffected.
+
 ### Plugin filesystem metadata is read-only through the Admin API
 
 The `plugin.path` and `plugin.managedByComposer` fields can no longer be created or changed through generic Admin API writes. Plugin discovery and extension management continue to maintain these values automatically. Integrations must not write plugin filesystem metadata directly.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -12,6 +12,10 @@ Three admin endpoints that previously only required authentication now enforce A
 * `GET /api/_action/scheduled-task/min-run-interval` requires the existing `scheduled_task:read` privilege.
 
 Administration users are not affected: both privileges are granted to every authenticated Administration user at runtime, because these endpoints back the admin worker that processes the message queue in every admin session. Integrations and API clients calling these endpoints must have the respective privilege added to their ACL role — the runtime defaults apply to Administration users only. External workers should keep using the `bin/console messenger:consume` and `scheduled-task:run` CLI commands, which are unaffected.
+### Plugin filesystem metadata is read-only through the Admin API
+
+The `plugin.path` and `plugin.managedByComposer` fields can no longer be created or changed through generic Admin API writes. Plugin discovery and extension management continue to maintain these values automatically. Integrations must not write plugin filesystem metadata directly.
+
 ### SEO admin action endpoints now require ACL privileges
 
 Four admin action endpoints that previously only required authentication now enforce ACL privileges. Requests with tokens lacking the privilege receive a `403` with `FRAMEWORK__MISSING_PRIVILEGE_ERROR`:

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -734,12 +734,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 2,
-    'path' => __DIR__ . '/src/Core/Framework/Plugin/PluginService.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',
     'identifier' => 'shopware.domainException',
     'count' => 1,

--- a/src/Core/Framework/Plugin/PluginDefinition.php
+++ b/src/Core/Framework/Plugin/PluginDefinition.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Plugin;
 
 use Shopware\Core\Checkout\Payment\PaymentMethodDefinition;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BlobField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
@@ -58,8 +59,8 @@ class PluginDefinition extends EntityDefinition
             (new StringField('composer_name', 'composerName'))->setDescription('Name of the composer package name.'),
             (new JsonField('autoload', 'autoload'))->addFlags(new Required())->setDescription('This ensures to automatically load all class files of a project before using them.'),
             (new BoolField('active', 'active'))->setDescription('When boolean value is `true`, the plugin is available.'),
-            (new BoolField('managed_by_composer', 'managedByComposer'))->setDescription('A property to check whether it is installed via composer or not.'),
-            (new StringField('path', 'path'))->setDescription('A relative URL to the plugin.'),
+            (new BoolField('managed_by_composer', 'managedByComposer'))->addFlags(new WriteProtected(Context::SYSTEM_SCOPE))->setDescription('A property to check whether it is installed via composer or not.'),
+            (new StringField('path', 'path'))->addFlags(new WriteProtected(Context::SYSTEM_SCOPE))->setDescription('A relative URL to the plugin.'),
             (new StringField('author', 'author'))->setDescription('Creator of the plugin.'),
             (new StringField('copyright', 'copyright'))->setDescription('Legal rights on the created plugin.'),
             (new StringField('license', 'license'))->setDescription('Software license\'s like MIT, etc.'),

--- a/src/Core/Framework/Plugin/PluginService.php
+++ b/src/Core/Framework/Plugin/PluginService.php
@@ -57,7 +57,7 @@ class PluginService
             $info = $pluginFromFileSystem->getComposerPackage();
 
             $autoload = $info->getAutoload();
-            if ($autoload === [] || (empty($autoload['psr-4']) && empty($autoload['psr-0']))) {
+            if ($autoload === [] || (($autoload['psr-4'] ?? []) === [] && ($autoload['psr-0'] ?? []) === [])) {
                 $errors->add(new PluginComposerJsonInvalidException(
                     $pluginPath . '/composer.json',
                     ['Neither a PSR-4 nor PSR-0 autoload information is given.']

--- a/src/Core/Framework/Plugin/PluginService.php
+++ b/src/Core/Framework/Plugin/PluginService.php
@@ -118,13 +118,15 @@ class PluginService
         }
 
         if ($plugins !== []) {
-            foreach ($plugins as $plugin) {
-                try {
-                    $this->pluginRepo->upsert([$plugin], $shopwareContext);
-                } catch (ShopwareHttpException $exception) {
-                    $errors->set($plugin['name'], $exception);
+            $shopwareContext->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($plugins, $errors): void {
+                foreach ($plugins as $plugin) {
+                    try {
+                        $this->pluginRepo->upsert([$plugin], $context);
+                    } catch (ShopwareHttpException $exception) {
+                        $errors->set($plugin['name'], $exception);
+                    }
                 }
-            }
+            });
         }
 
         // delete plugins, which are in storage but not in filesystem anymore
@@ -134,7 +136,9 @@ class PluginService
             foreach ($deletePluginIds as $deletePluginId) {
                 $deletePlugins[] = ['id' => $deletePluginId];
             }
-            $this->pluginRepo->delete($deletePlugins, $shopwareContext);
+            $shopwareContext->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($deletePlugins): void {
+                $this->pluginRepo->delete($deletePlugins, $context);
+            });
         }
 
         return $errors;

--- a/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
@@ -5,11 +5,13 @@ namespace Shopware\Tests\Integration\Core\Framework\Plugin;
 use Composer\IO\NullIO;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\PluginComposerJsonInvalidException;
 use Shopware\Core\Framework\Plugin\PluginCollection;
@@ -75,6 +77,46 @@ class PluginServiceTest extends TestCase
         static::assertSame('English description', $plugin->getDescription());
         static::assertSame('https://www.test.com/', $plugin->getManufacturerLink());
         static::assertSame('https://www.test.com/support', $plugin->getSupportLink());
+    }
+
+    public function testRefreshPluginsWithAdminApiContext(): void
+    {
+        $source = new AdminApiSource(Uuid::randomHex());
+        $source->setIsAdmin(true);
+
+        $this->pluginService->refreshPlugins(new Context($source), new NullIO());
+
+        $this->assertDefaultPlugin($this->fetchSwagTestPluginEntity());
+    }
+
+    public function testPluginPathIsWriteProtected(): void
+    {
+        $this->pluginService->refreshPlugins($this->context, new NullIO());
+        $plugin = $this->fetchSwagTestPluginEntity();
+
+        $source = new AdminApiSource(Uuid::randomHex());
+        $source->setIsAdmin(true);
+
+        $this->expectException(WriteException::class);
+        $this->pluginRepo->update([[
+            'id' => $plugin->getId(),
+            'path' => 'custom/plugins/ChangedPlugin',
+        ]], new Context($source));
+    }
+
+    public function testPluginComposerManagementIsWriteProtected(): void
+    {
+        $this->pluginService->refreshPlugins($this->context, new NullIO());
+        $plugin = $this->fetchSwagTestPluginEntity();
+
+        $source = new AdminApiSource(Uuid::randomHex());
+        $source->setIsAdmin(true);
+
+        $this->expectException(WriteException::class);
+        $this->pluginRepo->update([[
+            'id' => $plugin->getId(),
+            'managedByComposer' => false,
+        ]], new Context($source));
     }
 
     public function testRefreshPluginsWithRootComposerJsonContainingPlugin(): void

--- a/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\PluginComposerJsonInvalidException;
 use Shopware\Core\Framework\Plugin\PluginCollection;
@@ -86,36 +85,6 @@ class PluginServiceTest extends TestCase
         $this->pluginService->refreshPlugins(new Context($source), new NullIO());
 
         $this->assertDefaultPlugin($this->fetchSwagTestPluginEntity());
-    }
-
-    public function testPluginPathIsWriteProtected(): void
-    {
-        $this->pluginService->refreshPlugins($this->context, new NullIO());
-        $plugin = $this->fetchSwagTestPluginEntity();
-
-        $source = new AdminApiSource(Uuid::randomHex());
-        $source->setIsAdmin(true);
-
-        $this->expectException(WriteException::class);
-        $this->pluginRepo->update([[
-            'id' => $plugin->getId(),
-            'path' => 'custom/plugins/ChangedPlugin',
-        ]], new Context($source));
-    }
-
-    public function testPluginComposerManagementIsWriteProtected(): void
-    {
-        $this->pluginService->refreshPlugins($this->context, new NullIO());
-        $plugin = $this->fetchSwagTestPluginEntity();
-
-        $source = new AdminApiSource(Uuid::randomHex());
-        $source->setIsAdmin(true);
-
-        $this->expectException(WriteException::class);
-        $this->pluginRepo->update([[
-            'id' => $plugin->getId(),
-            'managedByComposer' => false,
-        ]], new Context($source));
     }
 
     public function testRefreshPluginsWithRootComposerJsonContainingPlugin(): void

--- a/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
@@ -16,7 +16,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\PluginComposerJsonInvalidException;
 use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
-use Shopware\Core\Framework\Plugin\PluginException;
 use Shopware\Core\Framework\Plugin\PluginService;
 use Shopware\Core\Framework\Plugin\Util\PluginFinder;
 use Shopware\Core\Framework\ShopwareHttpException;
@@ -273,23 +272,6 @@ class PluginServiceTest extends TestCase
         static::assertInstanceOf(PluginEntity::class, $plugin);
         $this->assertDefaultPlugin($plugin);
         static::assertNull($plugin->getUpgradeVersion());
-    }
-
-    public function testGetPluginByName(): void
-    {
-        $this->createPlugin($this->pluginRepo, $this->context);
-
-        $plugin = $this->pluginService->getPluginByName('SwagTestPlugin', $this->context);
-
-        $this->assertDefaultPlugin($plugin);
-    }
-
-    public function testGetPluginByNameThrowsException(): void
-    {
-        $this->createPlugin($this->pluginRepo, $this->context);
-
-        $this->expectExceptionObject(PluginException::notFound('SwagFoo'));
-        $this->pluginService->getPluginByName('SwagFoo', $this->context);
     }
 
     private function assertDefaultPlugin(PluginEntity $plugin): void

--- a/tests/unit/Core/Framework/Plugin/PluginServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginServiceTest.php
@@ -10,7 +10,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\PluginComposerJsonInvalidException;
 use Shopware\Core\Framework\Plugin\PluginCollection;
+use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginException;
 use Shopware\Core\Framework\Plugin\PluginService;
 use Shopware\Core\Framework\Plugin\Struct\PluginFromFileSystemStruct;
@@ -107,6 +109,16 @@ class PluginServiceTest extends TestCase
 
     public function testGetPluginByName(): void
     {
+        $plugin = (new PluginEntity())->assign(['id' => 'foo', 'name' => 'foo']);
+        $pluginRepo = new StaticEntityRepository([new PluginCollection([$plugin])]);
+        $pluginFinder = static::createStub(PluginFinder::class);
+        $pluginService = $this->getPluginService($pluginRepo, $pluginFinder);
+
+        static::assertSame($plugin, $pluginService->getPluginByName('foo', Context::createDefaultContext()));
+    }
+
+    public function testGetPluginByNameThrowsExceptionWhenPluginDoesNotExist(): void
+    {
         $pluginRepo = new StaticEntityRepository([new PluginCollection()]);
         $pluginFinder = static::createStub(PluginFinder::class);
         $pluginService = $this->getPluginService($pluginRepo, $pluginFinder);
@@ -115,9 +127,70 @@ class PluginServiceTest extends TestCase
         $pluginService->getPluginByName('foo', Context::createDefaultContext());
     }
 
-    private function getComposerPackage(): CompletePackage
+    public function testRefreshPluginsDeletesPluginsThatAreNotFoundOnTheFileSystem(): void
     {
-        $completePackage = new CompletePackage('foo', '1.0.0', '1.0.0');
+        $plugin = (new PluginEntity())->assign([
+            'id' => 'foo',
+            'baseClass' => 'Foo\\Plugin',
+        ]);
+        $pluginFinder = static::createStub(PluginFinder::class);
+        $pluginFinder->method('findPlugins')->willReturn([]);
+        $pluginRepo = new StaticEntityRepository([new PluginCollection([$plugin])]);
+
+        $this->getPluginService($pluginRepo, $pluginFinder)->refreshPlugins(
+            Context::createDefaultContext(),
+            static::createStub(IOInterface::class)
+        );
+
+        static::assertSame([[['id' => 'foo']]], $pluginRepo->deletes);
+    }
+
+    public function testRefreshPluginsReportsPluginsWithoutAutoloadInformation(): void
+    {
+        $package = $this->getComposerPackage();
+        $package->setAutoload([]);
+
+        $pluginFinder = static::createStub(PluginFinder::class);
+        $pluginFinder->method('findPlugins')->willReturn([
+            $this->getPluginFromFileSystemStruct($package),
+        ]);
+        $pluginRepo = new StaticEntityRepository([new PluginCollection()]);
+
+        $errors = $this->getPluginService($pluginRepo, $pluginFinder)->refreshPlugins(
+            Context::createDefaultContext(),
+            static::createStub(IOInterface::class)
+        );
+
+        static::assertCount(1, $errors);
+        static::assertInstanceOf(PluginComposerJsonInvalidException::class, $errors->first());
+        static::assertSame([], $pluginRepo->upserts);
+    }
+
+    public function testRefreshPluginsKeepsCurrentVersionAndSetsUpgradeVersionForAnInstalledPlugin(): void
+    {
+        $pluginFinder = static::createStub(PluginFinder::class);
+        $pluginFinder->method('findPlugins')->willReturn([$this->getPluginFromFileSystemStruct($this->getComposerPackage(version: '2.0.0'))]);
+
+        $plugin = (new PluginEntity())->assign([
+            'id' => 'foo',
+            'baseClass' => 'foo',
+            'version' => '1.0.0',
+            'installedAt' => new \DateTimeImmutable(),
+        ]);
+        $pluginRepo = new StaticEntityRepository([new PluginCollection([$plugin])]);
+
+        $this->getPluginService($pluginRepo, $pluginFinder)->refreshPlugins(
+            Context::createDefaultContext(),
+            static::createStub(IOInterface::class)
+        );
+
+        static::assertSame('1.0.0', $pluginRepo->upserts[0][0]['version']);
+        static::assertSame('2.0.0', $pluginRepo->upserts[0][0]['upgradeVersion']);
+    }
+
+    private function getComposerPackage(string $version = '1.0.0'): CompletePackage
+    {
+        $completePackage = new CompletePackage('foo', $version, $version);
         $completePackage->setAutoload([
             'psr-4' => [
                 'Foo\\' => 'bar',
@@ -133,6 +206,19 @@ class PluginServiceTest extends TestCase
         ]);
 
         return $completePackage;
+    }
+
+    private function getPluginFromFileSystemStruct(CompletePackage $package): PluginFromFileSystemStruct
+    {
+        $plugin = new PluginFromFileSystemStruct();
+        $plugin->assign([
+            'baseClass' => 'foo',
+            'path' => __DIR__,
+            'composerPackage' => $package,
+            'managedByComposer' => true,
+        ]);
+
+        return $plugin;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

Plugin filesystem metadata must be maintained by plugin discovery rather than generic Admin API writes.

### 2. What does this change do, exactly?

It makes `plugin.path` and `plugin.managedByComposer` system-write-protected, while running plugin discovery persistence in system scope. It also documents the Admin API contract and adds integration coverage. Focused PHPUnit, PHPStan, and PHP CS Fixer checks pass.

### 3. Describe each step to reproduce the issue or behaviour.

1. Discover a plugin.
2. Attempt to update its `path` or `managedByComposer` through a generic Admin API entity write.
3. The write is rejected; refreshing the plugin through extension management continues to succeed.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
