### PR TITLE
ci: stop the milestone check from failing on the labeler race

### DIFF
--- a/.github/bin/js/milestone-label.test.ts
+++ b/.github/bin/js/milestone-label.test.ts
@@ -64,6 +64,32 @@ test('a trunk PR without any milestone label is invalid', () => {
     assert.match(verdict.message, /no `milestone\/\*` label/);
 });
 
+test('a missing label is a race while the labeler is still running', () => {
+    // Regression: this failed on every newly opened pull request.
+    const racing = evaluateMilestoneLabel({
+        baseRefName: 'trunk',
+        defaultBranch: 'trunk',
+        labels: [],
+        versionBranches: VERSION_BRANCHES,
+        labelerPending: true,
+    });
+
+    assert.equal(racing.status, 'skipped');
+    assert.equal(evaluate([]).status, 'invalid');
+});
+
+test('a wrong label is invalid even while the labeler is still running', () => {
+    const verdict = evaluateMilestoneLabel({
+        baseRefName: 'trunk',
+        defaultBranch: 'trunk',
+        labels: [`${MILESTONE_LABEL_PREFIX}6.7.13.0`],
+        versionBranches: VERSION_BRANCHES,
+        labelerPending: true,
+    });
+
+    assert.equal(verdict.status, 'invalid');
+});
+
 test('a draft without a milestone label is left alone', () => {
     // Authors deliberately drop the label from long-running drafts, and a draft
     // cannot merge — set_milestone_label puts it back on ready_for_review.

--- a/.github/bin/js/milestone-label.ts
+++ b/.github/bin/js/milestone-label.ts
@@ -36,6 +36,11 @@ export type MilestoneLabelInput = {
     versionBranches: string[];
     /** A missing label is tolerated on drafts: authors drop it deliberately, and the labeler restores it on `ready_for_review`. */
     isDraft?: boolean;
+    /**
+     * Set on `opened`/`reopened`, where the labeler runs in parallel and wins by a
+     * fraction of a second, so a missing label is a race rather than a defect.
+     */
+    labelerPending?: boolean;
 };
 
 function releaseLineOf(branch: string): string | undefined {
@@ -81,7 +86,7 @@ function compareSegments(left: number[], right: number[]): number {
     return 0;
 }
 
-export function evaluateMilestoneLabel({ baseRefName, defaultBranch, labels, versionBranches, isDraft = false }: MilestoneLabelInput): MilestoneVerdict {
+export function evaluateMilestoneLabel({ baseRefName, defaultBranch, labels, versionBranches, isDraft = false, labelerPending = false }: MilestoneLabelInput): MilestoneVerdict {
     if (labels.includes(SKIP_CHECK_LABEL)) {
         return { status: 'skipped', message: `\`${SKIP_CHECK_LABEL}\` is set` };
     }
@@ -104,6 +109,10 @@ export function evaluateMilestoneLabel({ baseRefName, defaultBranch, labels, ver
     if (label === undefined) {
         if (isDraft) {
             return { status: 'skipped', message: `is a draft without a \`${MILESTONE_LABEL_PREFIX}*\` label; it gets one when it is marked ready for review` };
+        }
+
+        if (labelerPending) {
+            return { status: 'skipped', message: `has no \`${MILESTONE_LABEL_PREFIX}*\` label yet; the labeler is still running` };
         }
 
         return {
@@ -225,6 +234,7 @@ type PullRequestContext = {
     eventName?: string;
     repo: Repo;
     payload: {
+        action?: string;
         pull_request?: PullRequestPayload;
         merge_group?: MergeGroupPayload;
         repository?: { default_branch?: string };
@@ -253,7 +263,7 @@ function defaultBranchOf(context: PullRequestContext): string {
 /** `refs/heads/gh-readonly-queue/trunk/pr-18791-<base sha>` -> 18791 */
 const MERGE_GROUP_REF_PATTERN = /\/pr-(\d+)-[0-9a-f]+$/;
 
-type CheckedPullRequest = { number: number; baseRefName: string; labels: string[]; isDraft: boolean };
+type CheckedPullRequest = { number: number; baseRefName: string; labels: string[]; isDraft: boolean; labelerPending: boolean };
 
 /**
  * The queue may batch several PRs into one group while the ref names only the last,
@@ -302,6 +312,7 @@ async function pullRequestsToCheck({ github, core, context }: Toolkit): Promise<
             baseRefName: pullRequest.base.ref,
             labels: (pullRequest.labels ?? []).map((label) => label.name),
             isDraft: pullRequest.draft ?? false,
+            labelerPending: context.payload.action === 'opened' || context.payload.action === 'reopened',
         }];
     }
 
@@ -315,6 +326,7 @@ async function pullRequestsToCheck({ github, core, context }: Toolkit): Promise<
             baseRefName: data.base.ref,
             labels: data.labels.map((label) => label.name),
             isDraft: data.draft ?? false,
+            labelerPending: false,
         };
     }));
 }
@@ -342,6 +354,7 @@ export async function checkMilestoneLabel(toolkit: Toolkit): Promise<void> {
             labels: pullRequest.labels,
             versionBranches,
             isDraft: pullRequest.isDraft,
+            labelerPending: pullRequest.labelerPending,
         });
 
         const icon = { ok: '✅', skipped: '➖', invalid: '❌' }[verdict.status];

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -20,6 +20,11 @@ jobs:
     name: Set milestone label
     if: ${{ github.event_name == 'pull_request_target' && github.event.action != 'closed' && !contains(join(github.event.pull_request.labels.*.name, ','), 'milestone/') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Get versions
         id: versions
@@ -76,12 +81,23 @@ jobs:
             core.warning("This PR doesn't target 'trunk' or a version branch");
             return "skip";
 
+      # An app token is required for the added label to trigger the `labeled` run of
+      # milestone-check.yml; a label added with GITHUB_TOKEN starts no workflow. If
+      # minting fails the label still lands, the check just re-runs on the next push.
+      - id: sts-label
+        continue-on-error: true
+        uses: shopware/octo-sts-action@main
+        with:
+          scope: shopware
+          identity: CreatePR
+
       - name: Set milestone label
         if: ${{ steps.next-milestone.outputs.result != 'skip' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # 9
         env:
           MILESTONE: ${{ steps.next-milestone.outputs.result }}
         with:
+          github-token: ${{ steps.sts-label.outputs.token || secrets.GITHUB_TOKEN }}
           script: |
             const milestone = process.env.MILESTONE;
             const issueNumber = context.payload.pull_request.number;


### PR DESCRIPTION
### 1. Why is this change necessary?

The milestone check fails on every newly opened pull request, e.g. #18938. It and `set_milestone_label` both start on `opened`, and the labeler wins by a fraction of a second, so the check evaluates a payload without labels. The failure then stays: a label added with `GITHUB_TOKEN` triggers no workflow run, so the `labeled` trigger never fires and only a later push clears it.

### 2. What does this change do, exactly?

A missing label is tolerated while the labeler is still running (`opened`/`reopened`). A wrong label still fails, and `synchronize`, `labeled`, `ready_for_review` and the merge group keep enforcing a missing one.

`set_milestone_label` mints an app token for `addLabels`, so the label triggers the check and it turns green without waiting for a push. Same pattern as `01-pr-issue-labeler.yml`; if minting fails the label still lands.

### 3. Describe each step to reproduce the issue or behaviour.

Open any pull request against trunk and watch `Milestone label` fail with `has no milestone/* label` while the PR visibly carries one.

### 4. Please link to the relevant issues (if any).

Fixes the check introduced in #18845.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
