### PR TITLE
fix: guard CMS saves and disabled selects

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/index.js
@@ -126,6 +126,10 @@ export default {
         },
 
         collapse(event) {
+            if (!this.expanded) {
+                return;
+            }
+
             document.removeEventListener('click', this.listenToClickOutside);
             this.expanded = false;
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
@@ -11,7 +11,7 @@
         <div
             ref="selectWrapper"
             class="sw-select__selection"
-            tabindex="0"
+            :tabindex="disabled ? '-1' : '0'"
             :aria-expanded="expanded ? 'true' : 'false'"
             @click="expand"
             @focus="expand"

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.spec.js
@@ -64,6 +64,21 @@ describe('components/sw-select-base', () => {
         expect(clearableIcon.exists()).toBe(false);
     });
 
+    it('should remove disabled selects from the tab order', async () => {
+        const wrapper = await createWrapper({ disabled: true });
+
+        expect(wrapper.find('.sw-select__selection').attributes('tabindex')).toBe('-1');
+    });
+
+    it('should not emit a collapsed event when not expanded', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.expanded = false;
+
+        wrapper.vm.collapse();
+
+        expect(wrapper.emitted('select-collapsed')).toBeUndefined();
+    });
+
     it('should trigger clear event when user clicks on clearable icon', async () => {
         const wrapper = await createWrapper({ showClearableButton: true });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -39,7 +39,12 @@ export default {
     ],
 
     shortcuts: {
-        'SYSTEMKEY+S': 'onSave',
+        'SYSTEMKEY+S': {
+            method: 'onSave',
+            active() {
+                return this.canSave;
+            },
+        },
     },
 
     data() {
@@ -172,6 +177,10 @@ export default {
                 entity: null,
                 mode: 'static',
             };
+        },
+
+        canSave() {
+            return !this.isLoading && !this.page.locked && this.acl.can('cms.editor');
         },
 
         blockConfigDefaults() {
@@ -673,6 +682,10 @@ export default {
         onSave() {
             this.isSaveSuccessful = false;
 
+            if (!this.canSave) {
+                return Promise.resolve();
+            }
+
             if (!this.pageIsValid()) {
                 this.createNotificationError({
                     message: this.$t('sw-cms.detail.notification.pageInvalid'),
@@ -685,6 +698,10 @@ export default {
         },
 
         onSaveEntity() {
+            if (!this.canSave) {
+                return Promise.resolve();
+            }
+
             this.isLoading = true;
             this.deleteEntityAndRequiredConfigKey(this.page.sections);
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
@@ -113,7 +113,7 @@
                             class="sw-cms-detail__save-action"
                             :is-loading="isLoading"
                             :process-success="isSaveSuccessful"
-                            :disabled="isLoading || page.locked || !acl.can('cms.editor') || undefined"
+                            :disabled="!canSave || undefined"
                             variant="primary"
                             @update:process-success="saveFinish"
                             @click="onSave"
@@ -241,7 +241,7 @@
                             </p>
                             <sw-cms-stage-add-section
                                 :key="0"
-                                :disabled="!acl.can('cms.editor') || undefined"
+                                :disabled="!canSave || undefined"
                                 :force-choose="true"
                                 @stage-section-add="onAddSection($event, 0, true)"
                             />
@@ -262,7 +262,7 @@
                         {% block sw_cms_detail_stage_add_first_section %}
                         <sw-cms-stage-add-section
                             :key="0"
-                            :disabled="!acl.can('cms.editor') || undefined"
+                            :disabled="!canSave || undefined"
                             @stage-section-add="onAddSection($event, 0, true)"
                         />
                         {% endblock %}
@@ -280,7 +280,7 @@
                                     :page="page"
                                     :section="section"
                                     :active="selectedSection !== null && selectedSection.id === section.id"
-                                    :disabled="!acl.can('cms.editor') || undefined"
+                                    :disabled="!canSave || undefined"
                                     @page-config-open="pageConfigOpen"
                                     @block-duplicate="onBlockDuplicate"
                                 />
@@ -292,7 +292,7 @@
                         {% block sw_cms_detail_stage_add_last_section %}
                         <sw-cms-stage-add-section
                             :key="page.sections.length + 1"
-                            :disabled="!acl.can('cms.editor') || undefined"
+                            :disabled="!canSave || undefined"
                             @stage-section-add="onAddSection($event, page.sections.length, true)"
                         />
                         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
@@ -337,6 +337,46 @@ describe('module/sw-cms/page/sw-cms-detail', () => {
         expect(cmsSidebar.attributes().disabled).toBeUndefined();
     });
 
+    it.each([
+        [
+            'missing ACL rights',
+            [],
+            false,
+        ],
+        [
+            'a locked page',
+            ['cms.editor'],
+            false,
+        ],
+        [
+            'a loading page',
+            ['cms.editor'],
+            false,
+        ],
+    ])('should not save when %s', async (reason, aclRoles, expectedCanSave) => {
+        global.activeAclRoles = aclRoles;
+
+        const wrapper = await createWrapper();
+        await flushPromises();
+        await wrapper.setData({
+            isLoading: reason === 'a loading page',
+            page: {
+                locked: reason === 'a locked page',
+            },
+        });
+
+        const saveSpy = jest.spyOn(wrapper.vm.pageRepository, 'save');
+
+        expect(wrapper.vm.canSave).toBe(expectedCanSave);
+        expect(wrapper.find('.sw-cms-detail__save-action').attributes().disabled).toBe('true');
+        expect(wrapper.vm.$options.shortcuts['SYSTEMKEY+S'].active.call(wrapper.vm)).toBe(false);
+
+        await wrapper.vm.onSave();
+        await wrapper.vm.onSaveEntity();
+
+        expect(saveSpy).not.toHaveBeenCalled();
+    });
+
     it('should have warning message if there are more than 1 product page element in product page layout', async () => {
         const wrapper = await createWrapper();
         await flushPromises();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Selects can clear their values when tabbed out while not expanded. Disabled selects can also receive focus, and locked CMS pages can activate save or editor controls via keyboard.

### 2. What does this change do, exactly?

Prevents collapse events for unopened selects, removes disabled selects from the tab order, centralizes CMS saveability checks, and disables Add Section/sidebar controls on locked pages.

### 3. Describe each step to reproduce the issue or behaviour.

Open a CMS layout, focus a select, and tab through the controls. On a locked page, use Tab + Enter on Add Section/sidebar controls or press Ctrl/Cmd + S.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #18793.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
