### PR TITLE
fix(framework): enforce app permissions for extension SDK

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -804,6 +804,10 @@ The route is guarded by the existing `media:read` ACL privilege and returns a sm
 
 ## App System
 
+### App permissions restrict Extension SDK requests and Administration modules
+
+Extension SDK action and URI-signing requests now require `app.all` or `app.<appName>` for the selected app. Target URLs must be absolute and use a host declared in the app manifest's `allowed-hosts`. The Administration module response omits modules for apps the current user cannot access. Assign the relevant app privilege to users or integrations that need to use an app's Administration features, and keep the app's target hosts declared in its manifest.
+
 ### Deprecation of inline `<custom-fields>` in `manifest.xml`
 
 Defining custom fields inline in `manifest.xml` via the `<custom-fields>` element is deprecated. Use a separate `Resources/config/custom-fields.xml` file instead. The inline definition will be removed in v6.8.0.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -806,7 +806,10 @@ The route is guarded by the existing `media:read` ACL privilege and returns a sm
 
 ### App permissions restrict Extension SDK requests and Administration modules
 
-Extension SDK action and URI-signing requests now require `app.all` or `app.<appName>` for the selected app. Target URLs must be absolute and use a host declared in the app manifest's `allowed-hosts`. The Administration module response omits modules for apps the current user cannot access. Assign the relevant app privilege to users or integrations that need to use an app's Administration features, and keep the app's target hosts declared in its manifest.
+Extension SDK action and URI-signing requests now require `app.all` or `app.<appName>` ACL rights for the selected app.
+Target URLs must be absolute and use a host declared in the app manifest's `allowed-hosts`.
+The Administration module response omits modules for apps the current user cannot access.
+Assign the relevant app privilege to users or integrations that need to use an app's Administration features, and keep the app's target hosts declared in its manifest.
 
 ### Deprecation of inline `<custom-fields>` in `manifest.xml`
 

--- a/src/Administration/Controller/AdminExtensionApiController.php
+++ b/src/Administration/Controller/AdminExtensionApiController.php
@@ -44,7 +44,10 @@ class AdminExtensionApiController extends AbstractController
     #[Route(path: '/api/_action/extension-sdk/run-action', name: 'api.action.extension-sdk.run-action', methods: ['POST'])]
     public function runAction(RequestDataBag $requestDataBag, Context $context): Response
     {
-        $appName = $requestDataBag->get('appName');
+        $appName = $requestDataBag->getString('appName');
+        if ($appName === '') {
+            throw AppException::missingRequestParameter('appName');
+        }
 
         if (!$context->isAllowed('app.all') && !$context->isAllowed('app.' . $appName)) {
             throw ApiException::missingPrivileges(['app.' . $appName]);
@@ -65,7 +68,16 @@ class AdminExtensionApiController extends AbstractController
         }
 
         $targetUrl = $requestDataBag->getString('url');
-        $targetHost = \parse_url($targetUrl, \PHP_URL_HOST);
+        if ($targetUrl === '') {
+            throw AppException::missingRequestParameter('url');
+        }
+
+        $urlParts = \parse_url($targetUrl);
+        if ($urlParts === false || !isset($urlParts['scheme'], $urlParts['host'])) {
+            throw AppException::invalidArgument(\sprintf('%s is not a valid url', $targetUrl));
+        }
+
+        $targetHost = $urlParts['host'];
         $allowedHosts = $app->getAllowedHosts() ?? [];
         if (!$targetHost || !\in_array($targetHost, $allowedHosts, true)) {
             throw AppException::hostNotAllowed($targetUrl, $app->getName());
@@ -92,7 +104,15 @@ class AdminExtensionApiController extends AbstractController
     #[Route(path: '/api/_action/extension-sdk/sign-uri', name: 'api.action.extension-sdk.sign-uri', methods: ['POST'])]
     public function signUri(RequestDataBag $requestDataBag, Context $context): Response
     {
-        $appName = $requestDataBag->get('appName');
+        $appName = $requestDataBag->getString('appName');
+        if ($appName === '') {
+            throw AppException::missingRequestParameter('appName');
+        }
+
+        if (!$context->isAllowed('app.all') && !$context->isAllowed('app.' . $appName)) {
+            throw ApiException::missingPrivileges(['app.' . $appName]);
+        }
+
         $criteria = new Criteria();
         $criteria->addFilter(
             new EqualsFilter('name', $appName)
@@ -103,7 +123,23 @@ class AdminExtensionApiController extends AbstractController
             throw AppException::appNotFoundByName($appName);
         }
 
-        $uri = $this->querySigner->signUri($requestDataBag->get('uri'), $app, $context)->__toString();
+        $uri = $requestDataBag->getString('uri');
+        if ($uri === '') {
+            throw AppException::missingRequestParameter('uri');
+        }
+
+        $uriParts = \parse_url($uri);
+        if ($uriParts === false || !isset($uriParts['scheme'], $uriParts['host'])) {
+            throw AppException::invalidArgument(\sprintf('%s is not a valid url', $uri));
+        }
+
+        $targetHost = $uriParts['host'];
+        $allowedHosts = $app->getAllowedHosts() ?? [];
+        if (!$targetHost || !\in_array($targetHost, $allowedHosts, true)) {
+            throw AppException::hostNotAllowed($uri, $app->getName());
+        }
+
+        $uri = $this->querySigner->signUri($uri, $app, $context)->__toString();
 
         return new JsonResponse([
             'uri' => $uri,

--- a/src/Core/Framework/App/Manifest/ModuleLoader.php
+++ b/src/Core/Framework/App/Manifest/ModuleLoader.php
@@ -71,6 +71,10 @@ class ModuleLoader
         $appModules = [];
 
         foreach ($apps as $app) {
+            if (!$context->isAllowed('app.all') && !$context->isAllowed('app.' . $app->getName())) {
+                continue;
+            }
+
             $modules = $this->formatModules($app, $context);
             $mainModule = $this->formatMainModule($app, $context);
 

--- a/tests/integration/Administration/Controller/AdminExtensionApiControllerTest.php
+++ b/tests/integration/Administration/Controller/AdminExtensionApiControllerTest.php
@@ -206,6 +206,7 @@ class AdminExtensionApiControllerTest extends TestCase
                     'name' => self::EXISTING_APP_NAME,
                     'privileges' => [],
                 ],
+                'allowedHosts' => ['app.infra'],
             ],
         ], $this->context);
 

--- a/tests/integration/Core/Framework/App/Manifest/ModuleLoaderTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/ModuleLoaderTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\App\Manifest;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\Manifest\ModuleLoader;
 use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
@@ -115,6 +116,38 @@ class ModuleLoaderTest extends TestCase
         $loadedModules = $this->getSortedModules();
 
         static::assertSame([], $loadedModules);
+    }
+
+    public function testLoadModulesFiltersAppsWithoutPermission(): void
+    {
+        $this->createApp('AllowedApp', [
+            'modules' => [
+                [
+                    'label' => ['en-GB' => 'allowed module'],
+                    'source' => 'https://allowed.app.com',
+                    'name' => 'allowed-module',
+                ],
+            ],
+        ]);
+        $this->createApp('ForbiddenApp', [
+            'modules' => [
+                [
+                    'label' => ['en-GB' => 'forbidden module'],
+                    'source' => 'https://forbidden.app.com',
+                    'name' => 'forbidden-module',
+                ],
+            ],
+        ]);
+
+        $source = new AdminApiSource(null);
+        $source->setPermissions(['app.AllowedApp']);
+        $context = Context::createDefaultContext($source);
+
+        $modules = $this->moduleLoader->loadModules($context);
+
+        static::assertCount(1, $modules);
+        static::assertSame('AllowedApp', $modules[0]['name']);
+        static::assertSame('allowed-module', $modules[0]['modules'][0]['name']);
     }
 
     public function testMainModules(): void

--- a/tests/unit/Administration/Controller/AdminExtensionApiControllerTest.php
+++ b/tests/unit/Administration/Controller/AdminExtensionApiControllerTest.php
@@ -71,6 +71,13 @@ class AdminExtensionApiControllerTest extends TestCase
         $this->controller->runAction(new RequestDataBag(['appName' => 'test-app']), $this->context);
     }
 
+    public function testRunActionThrowsMissingRequestParameterWhenAppNameIsMissing(): void
+    {
+        $this->expectExceptionObject(AppException::missingRequestParameter('appName'));
+
+        $this->controller->runAction(new RequestDataBag(), $this->context);
+    }
+
     public function testRunActionThrowsAppByNameNotFoundExceptionWhenAppSecretIsNull(): void
     {
         $this->expectExceptionObject(AppException::appSecretMissing('test-app'));
@@ -81,9 +88,9 @@ class AdminExtensionApiControllerTest extends TestCase
         $this->buildController(entityRepository: $entityRepository)->runAction(new RequestDataBag(['appName' => $entity->getName()]), $this->context);
     }
 
-    public function testRunActionThrowsUnallowedHostExceptionWhenTargetHostIsEmpty(): void
+    public function testRunActionThrowsMissingRequestParameterWhenUrlIsMissing(): void
     {
-        $this->expectExceptionObject(AppException::hostNotAllowed('', 'test-app'));
+        $this->expectExceptionObject(AppException::missingRequestParameter('url'));
 
         $entity = $this->buildAppEntity('test-app', 'test-secrets', []);
         $entityRepository = $this->assertEntityRepositoryWithEntity($entity);
@@ -91,15 +98,28 @@ class AdminExtensionApiControllerTest extends TestCase
         $this->buildController(entityRepository: $entityRepository)->runAction(new RequestDataBag(['appName' => $entity->getName()]), $this->context);
     }
 
-    public function testRunActionThrowsUnallowedHostExceptionWhenTargetHostIsNotAllowed(): void
+    public function testRunActionThrowsInvalidArgumentExceptionWhenUrlIsNotValid(): void
     {
-        $this->expectExceptionObject(AppException::hostNotAllowed('test-host', 'test-app'));
+        $this->expectExceptionObject(AppException::invalidArgument('test-host is not a valid url'));
 
         $entity = $this->buildAppEntity('test-app', 'test-secrets', ['shopware']);
         $entityRepository = $this->assertEntityRepositoryWithEntity($entity);
 
         $this->buildController(entityRepository: $entityRepository)->runAction(
             new RequestDataBag(['appName' => $entity->getName(), 'url' => 'test-host']),
+            $this->context
+        );
+    }
+
+    public function testRunActionThrowsUnallowedHostExceptionWhenTargetHostIsNotAllowed(): void
+    {
+        $this->expectExceptionObject(AppException::hostNotAllowed('https://not-allowed.example', 'test-app'));
+
+        $entity = $this->buildAppEntity('test-app', 'test-secrets', ['shopware']);
+        $entityRepository = $this->assertEntityRepositoryWithEntity($entity);
+
+        $this->buildController(entityRepository: $entityRepository)->runAction(
+            new RequestDataBag(['appName' => $entity->getName(), 'url' => 'https://not-allowed.example']),
             $this->context
         );
     }
@@ -176,22 +196,110 @@ class AdminExtensionApiControllerTest extends TestCase
     {
         $this->expectException(AppNotFoundException::class);
 
-        $this->controller->signUri(new RequestDataBag(['appName' => 'test-app']), $this->context);
+        $source = new AdminApiSource(Uuid::randomHex());
+        $source->setPermissions(['app.test-app']);
+
+        $this->controller->signUri(
+            new RequestDataBag(['appName' => 'test-app']),
+            Context::createDefaultContext($source)
+        );
+    }
+
+    public function testSignUriThrowsMissingPrivilegeWhenUserLacksAppPrivilege(): void
+    {
+        $this->expectExceptionObject(ApiException::missingPrivileges(['app.test-app']));
+
+        $querySigner = $this->createMock(QuerySigner::class);
+        $querySigner->expects($this->never())->method('signUri');
+        $source = new AdminApiSource(Uuid::randomHex());
+        $source->setPermissions(['product:read']);
+
+        $this->buildController(querySigner: $querySigner)->signUri(
+            new RequestDataBag(['appName' => 'test-app']),
+            Context::createDefaultContext($source)
+        );
+    }
+
+    public function testSignUriThrowsMissingRequestParameterWhenAppNameIsMissing(): void
+    {
+        $this->expectExceptionObject(AppException::missingRequestParameter('appName'));
+
+        $this->controller->signUri(new RequestDataBag(), $this->context);
+    }
+
+    public function testSignUriThrowsMissingRequestParameterWhenUriIsMissing(): void
+    {
+        $entity = $this->buildAppEntity('test-app', 'test-secrets', ['foo.bar']);
+        $entityRepository = $this->assertEntityRepositoryWithEntity($entity);
+        $querySigner = $this->createMock(QuerySigner::class);
+        $querySigner->expects($this->never())->method('signUri');
+        $source = new AdminApiSource(Uuid::randomHex());
+        $source->setPermissions(['app.test-app']);
+
+        $this->expectExceptionObject(AppException::missingRequestParameter('uri'));
+
+        $this->buildController(querySigner: $querySigner, entityRepository: $entityRepository)->signUri(
+            new RequestDataBag(['appName' => 'test-app']),
+            Context::createDefaultContext($source)
+        );
+    }
+
+    public function testSignUriThrowsInvalidArgumentWhenUriIsNotValid(): void
+    {
+        $entity = $this->buildAppEntity('test-app', 'test-secrets', ['foo.bar']);
+        $entityRepository = $this->assertEntityRepositoryWithEntity($entity);
+        $querySigner = $this->createMock(QuerySigner::class);
+        $querySigner->expects($this->never())->method('signUri');
+        $source = new AdminApiSource(Uuid::randomHex());
+        $source->setPermissions(['app.test-app']);
+
+        $this->expectExceptionObject(AppException::invalidArgument('not-a-url is not a valid url'));
+
+        $this->buildController(querySigner: $querySigner, entityRepository: $entityRepository)->signUri(
+            new RequestDataBag([
+                'appName' => 'test-app',
+                'uri' => 'not-a-url',
+            ]),
+            Context::createDefaultContext($source)
+        );
+    }
+
+    public function testSignUriThrowsHostNotAllowedWhenUriHostIsNotAllowed(): void
+    {
+        $entity = $this->buildAppEntity('test-app', 'test-secrets', ['allowed.example']);
+        $entityRepository = $this->assertEntityRepositoryWithEntity($entity);
+        $querySigner = $this->createMock(QuerySigner::class);
+        $querySigner->expects($this->never())->method('signUri');
+        $source = new AdminApiSource(Uuid::randomHex());
+        $source->setPermissions(['app.test-app']);
+
+        $this->expectExceptionObject(AppException::hostNotAllowed('https://evil.example/action', 'test-app'));
+
+        $this->buildController(querySigner: $querySigner, entityRepository: $entityRepository)->signUri(
+            new RequestDataBag([
+                'appName' => 'test-app',
+                'uri' => 'https://evil.example/action',
+            ]),
+            Context::createDefaultContext($source)
+        );
     }
 
     public function testSignUriReturnsJsonResponseWithUri(): void
     {
         $entity = $this->buildAppEntity('test-app', 'test-secrets', ['foo.bar']);
         $entityRepository = $this->assertEntityRepositoryWithEntity($entity);
+        $source = new AdminApiSource(Uuid::randomHex());
+        $source->setPermissions(['app.all']);
+        $context = Context::createDefaultContext($source);
 
-        $requestBag = new RequestDataBag(['appName' => $entity->getName(), 'uri' => 'test-uri']);
+        $requestBag = new RequestDataBag(['appName' => $entity->getName(), 'uri' => 'https://foo.bar/test-uri']);
 
         $querySigner = $this->createMock(QuerySigner::class);
         $querySigner->expects($this->once())->method('signUri')
-            ->with($requestBag->get('uri'), $entity, $this->context)
+            ->with($requestBag->get('uri'), $entity, $context)
             ->willReturn(static::createStub(UriInterface::class));
 
-        $response = $this->buildController(querySigner: $querySigner, entityRepository: $entityRepository)->signUri($requestBag, $this->context);
+        $response = $this->buildController(querySigner: $querySigner, entityRepository: $entityRepository)->signUri($requestBag, $context);
 
         static::assertNotFalse($response->getContent());
         static::assertJsonStringEqualsJsonString('{"uri":""}', $response->getContent());

--- a/tests/unit/Core/Framework/App/Manifest/ModuleLoaderTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/ModuleLoaderTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Manifest;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\Hmac\QuerySigner;
+use Shopware\Core\Framework\App\Manifest\ModuleLoader;
+use Shopware\Core\Framework\App\ShopId\ShopId;
+use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Tests\Unit\Core\Framework\App\AppFixture;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(ModuleLoader::class)]
+class ModuleLoaderTest extends TestCase
+{
+    public function testLoadModulesSkipsAppsWithoutPermissionBeforeSigningModules(): void
+    {
+        $app = AppFixture::createAppEntity('ForbiddenApp');
+        $app->setModules([
+            [
+                'label' => ['en-GB' => 'forbidden module'],
+                'source' => 'https://forbidden.app.com',
+                'name' => 'forbidden-module',
+                'parent' => 'sw-catalogue',
+                'position' => 50,
+            ],
+        ]);
+
+        $querySigner = $this->createMock(QuerySigner::class);
+        $querySigner->expects($this->never())->method('signUri');
+
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->expects($this->once())->method('getShopId')->willReturn(ShopId::v2('shop-id'));
+
+        $source = new AdminApiSource(null);
+        $source->setPermissions(['app.AllowedApp']);
+
+        $moduleLoader = new ModuleLoader(
+            new StaticEntityRepository([new AppCollection([$app])]),
+            $shopIdProvider,
+            $querySigner,
+        );
+
+        static::assertSame([], $moduleLoader->loadModules(Context::createDefaultContext($source)));
+    }
+}

--- a/tests/unit/Core/Framework/App/Manifest/ModuleLoaderTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/ModuleLoaderTest.php
@@ -56,11 +56,17 @@ class ModuleLoaderTest extends TestCase
                 'label' => ['en-GB' => 'module with source'],
                 'source' => 'https://module.app.com',
                 'name' => 'module-with-source',
-                'parent' => null,
+                'parent' => 'sw-catalogue',
                 'position' => 20,
             ],
         ]);
-        $app->setMainModule(['source' => 'https://main.app.com']);
+        $app->setMainModule([
+            'source' => 'https://main.app.com',
+            'name' => 'main-module',
+            'label' => ['en-GB' => 'main module'],
+            'parent' => 'sw-catalogue',
+            'position' => 0,
+        ]);
 
         $shopIdProvider = $this->createMock(ShopIdProvider::class);
         $shopIdProvider->expects($this->once())->method('getShopId')->willReturn(ShopId::v2('shop-id'));
@@ -95,7 +101,7 @@ class ModuleLoaderTest extends TestCase
                         'label' => ['en-GB' => 'module with source'],
                         'source' => 'https://module.app.com?signed=true',
                         'name' => 'module-with-source',
-                        'parent' => null,
+                        'parent' => 'sw-catalogue',
                         'position' => 20,
                     ],
                 ],

--- a/tests/unit/Core/Framework/App/Manifest/ModuleLoaderTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/ModuleLoaderTest.php
@@ -2,12 +2,15 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\App\Manifest;
 
+use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\Hmac\QuerySigner;
 use Shopware\Core\Framework\App\Manifest\ModuleLoader;
+use Shopware\Core\Framework\App\ShopId\FingerprintComparisonResult;
 use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
@@ -22,6 +25,101 @@ use Shopware\Tests\Unit\Core\Framework\App\AppFixture;
 #[CoversClass(ModuleLoader::class)]
 class ModuleLoaderTest extends TestCase
 {
+    public function testLoadModulesReturnsNothingWhenShopIdChangeWasSuggested(): void
+    {
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->expects($this->once())->method('getShopId')->willThrowException(
+            new ShopIdChangeSuggestedException(ShopId::v2('shop-id'), new FingerprintComparisonResult([], [], 75))
+        );
+
+        $moduleLoader = new ModuleLoader(
+            new StaticEntityRepository([new AppCollection()]),
+            $shopIdProvider,
+            static::createStub(QuerySigner::class),
+        );
+
+        static::assertSame([], $moduleLoader->loadModules(Context::createDefaultContext()));
+    }
+
+    public function testLoadModulesFormatsAuthorizedModulesAndMainModule(): void
+    {
+        $app = AppFixture::createAppEntity('AllowedApp');
+        $app->setModules([
+            [
+                'label' => ['en-GB' => 'module without source'],
+                'source' => null,
+                'name' => 'module-without-source',
+                'parent' => 'sw-catalogue',
+                'position' => 10,
+            ],
+            [
+                'label' => ['en-GB' => 'module with source'],
+                'source' => 'https://module.app.com',
+                'name' => 'module-with-source',
+                'parent' => null,
+                'position' => 20,
+            ],
+        ]);
+        $app->setMainModule(['source' => 'https://main.app.com']);
+
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->expects($this->once())->method('getShopId')->willReturn(ShopId::v2('shop-id'));
+
+        $querySigner = $this->createMock(QuerySigner::class);
+        $querySigner->expects($this->exactly(2))->method('signUri')->willReturnCallback(
+            static fn (string $source): Uri => new Uri($source . '?signed=true')
+        );
+
+        $source = new AdminApiSource(null);
+        $source->setPermissions(['app.AllowedApp']);
+
+        $moduleLoader = new ModuleLoader(
+            new StaticEntityRepository([new AppCollection([$app])]),
+            $shopIdProvider,
+            $querySigner,
+        );
+
+        static::assertSame([
+            [
+                'name' => 'AllowedApp',
+                'label' => [],
+                'modules' => [
+                    [
+                        'label' => ['en-GB' => 'module without source'],
+                        'source' => null,
+                        'name' => 'module-without-source',
+                        'parent' => 'sw-catalogue',
+                        'position' => 10,
+                    ],
+                    [
+                        'label' => ['en-GB' => 'module with source'],
+                        'source' => 'https://module.app.com?signed=true',
+                        'name' => 'module-with-source',
+                        'parent' => null,
+                        'position' => 20,
+                    ],
+                ],
+                'mainModule' => ['source' => 'https://main.app.com?signed=true'],
+            ],
+        ], $moduleLoader->loadModules(Context::createDefaultContext($source)));
+    }
+
+    public function testLoadModulesSkipsAppsWithoutModulesOrMainModule(): void
+    {
+        $app = AppFixture::createAppEntity('EmptyApp');
+        $app->setModules([]);
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->expects($this->once())->method('getShopId')->willReturn(ShopId::v2('shop-id'));
+
+        $moduleLoader = new ModuleLoader(
+            new StaticEntityRepository([new AppCollection([$app])]),
+            $shopIdProvider,
+            static::createStub(QuerySigner::class),
+        );
+
+        static::assertSame([], $moduleLoader->loadModules(Context::createDefaultContext()));
+    }
+
     public function testLoadModulesSkipsAppsWithoutPermissionBeforeSigningModules(): void
     {
         $app = AppFixture::createAppEntity('ForbiddenApp');


### PR DESCRIPTION
### 1. Why is this change necessary?

The Extension SDK endpoints could process app requests without consistently validating the selected app, target URL, and Administration user's app permissions. The Administration module loader also exposed modules for apps the current user could not access.

### 2. What does this change do, exactly?

- Validates required app names and URLs for the Extension SDK action and URI-signing endpoints.
- Requires either `app.all` or the selected app's `app.<appName>` privilege.
- Restricts target URLs to valid absolute URLs and the selected app's configured allowed hosts.
- Filters unauthorized apps out of the Administration module payload before their module URLs are signed.
- Adds regression coverage for authorization, validation, host restrictions, and module filtering.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install multiple apps with Administration modules.
2. Authenticate as an Administration user with access to only one app.
3. Request the Extension SDK action/signing endpoints or the app-system modules endpoint.
4. Only the permitted app and valid, allowed target URLs are accepted.

### 4. Please link to the relevant issues (if any).

No linked issue.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this is relevant for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them