### PR TITLE
fix: defer CMS editor deletions until save

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
@@ -635,6 +635,10 @@ export default Shopware.Component.wrapComponentConfig({
         onSectionDelete(sectionId: string) {
             Shopware.Store.get('cmsPage').removeSelectedSection();
             this.page.sections!.remove(sectionId);
+        },
+
+        onNavigatorSectionDelete(sectionId: string) {
+            this.onSectionDelete(sectionId);
             this.$emit('page-save');
         },
 
@@ -648,7 +652,10 @@ export default Shopware.Component.wrapComponentConfig({
             if (this.selectedBlock && this.selectedBlock.id === block.id) {
                 Shopware.Store.get('cmsPage').removeSelectedBlock();
             }
+        },
 
+        onNavigatorBlockDelete(block: Entity<'cms_block'>, section: Entity<'cms_section'>) {
+            this.onBlockDelete(block, section);
             this.$emit('page-save', true);
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
@@ -394,7 +394,7 @@
                         <sw-context-menu-item
                             class="sw-cms-sidebar__navigator-section-delete"
                             variant="danger"
-                            @click="onSectionDelete(section.id)"
+                            @click="onNavigatorSectionDelete(section.id)"
                         >
                             {{ $t('global.default.delete') }}
                         </sw-context-menu-item>
@@ -419,7 +419,7 @@
                             :removable="blockIsRemovable(block)"
                             :duplicable="blockIsDuplicable(block)"
                             :class="{ 'is--dragging': block.isDragging }"
-                            @block-delete="onBlockDelete($event, section)"
+                            @block-delete="onNavigatorBlockDelete($event, section)"
                             @block-duplicate="onBlockDuplicate($event, section)"
                         />
                     </template>
@@ -456,7 +456,7 @@
                                 :removable="blockIsRemovable(block)"
                                 class="sw-cms-sidebar__navigator-block is--sidebar"
                                 :class="{ 'is--dragging': block.isDragging }"
-                                @block-delete="onBlockDelete($event, section)"
+                                @block-delete="onNavigatorBlockDelete($event, section)"
                                 @block-duplicate="onBlockDuplicate($event, section)"
                             />
                         </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
@@ -25,6 +25,10 @@ function getBlockCollection(blocks) {
     return new EntityCollection(blocks, 'blocks', null, null, blocks);
 }
 
+function getSectionCollection(sections) {
+    return new EntityCollection(sections, 'sections', null, null, sections);
+}
+
 async function createWrapper(
     { cmsBlockRegistry } = { cmsBlockRegistry: null },
     pageType = 'product_list',
@@ -72,6 +76,9 @@ async function createWrapper(
             removeSelectedBlock() {
                 this.selectedBlock = null;
             },
+            removeSelectedSection() {
+                this.selectedSection = null;
+            },
             setSection(section) {
                 this.removeSelectedBlock();
                 this.setSelectedSection(section);
@@ -86,30 +93,34 @@ async function createWrapper(
         {
             props: {
                 page: {
-                    sections: [
+                    sections: getSectionCollection([
                         new Entity('1111', 'section', {
                             type: 'sidebar',
                             blocks: getBlockCollection([
                                 {
                                     id: '1a2b',
+                                    sectionId: '1111',
                                     sectionPosition: 'main',
                                     type: 'foo-bar',
                                     slots: [],
                                 },
                                 {
                                     id: '3cd4',
+                                    sectionId: '1111',
                                     sectionPosition: 'sidebar',
                                     type: 'foo-bar',
                                     slots: [],
                                 },
                                 {
                                     id: '5ef6',
+                                    sectionId: '1111',
                                     sectionPosition: 'sidebar',
                                     type: 'foo-bar-removed',
                                     slots: [],
                                 },
                                 {
                                     id: '7gh8',
+                                    sectionId: '1111',
                                     sectionPosition: 'main',
                                     type: 'foo-bar-removed',
                                     slots: [],
@@ -121,13 +132,14 @@ async function createWrapper(
                             blocks: getBlockCollection([
                                 {
                                     id: 'abcd',
+                                    sectionId: '2222',
                                     sectionPosition: 'main',
                                     type: 'some-type',
                                     slots: [],
                                 },
                             ]),
                         }),
-                    ],
+                    ]),
                     type: pageType,
                 },
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec/delete.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec/delete.spec.js
@@ -1,0 +1,101 @@
+/**
+ * @sw-package discovery
+ */
+import 'src/module/sw-cms/mixin/sw-cms-state.mixin';
+
+const { EntityCollection } = Shopware.Data;
+
+async function getMethods() {
+    const component = await wrapTestComponent('sw-cms-sidebar', {
+        sync: true,
+    });
+
+    return component.methods;
+}
+
+function createPage() {
+    const block = {
+        id: 'block-id',
+        sectionId: 'section-id',
+    };
+    const section = {
+        id: 'section-id',
+        blocks: new EntityCollection(null, 'cms_block', null, null, [block]),
+    };
+
+    return {
+        block,
+        page: {
+            sections: new EntityCollection(null, 'cms_section', null, null, [section]),
+        },
+        section,
+    };
+}
+
+describe('module/sw-cms/component/sw-cms-sidebar/delete', () => {
+    beforeEach(() => {
+        jest.spyOn(Shopware.Store, 'get').mockReturnValue({
+            removeSelectedBlock: jest.fn(),
+            removeSelectedSection: jest.fn(),
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('does not save when removing a block from the editor', async () => {
+        const methods = await getMethods();
+        const { block, page, section } = createPage();
+        const $emit = jest.fn();
+
+        methods.onBlockDelete.call({ $emit, page, selectedBlock: block }, block);
+
+        expect(section.blocks.has(block.id)).toBeFalsy();
+        expect($emit).not.toHaveBeenCalled();
+    });
+
+    it('saves when removing a block from the navigator', async () => {
+        const methods = await getMethods();
+        const { block, page, section } = createPage();
+        const $emit = jest.fn();
+        const context = {
+            $emit,
+            onBlockDelete: methods.onBlockDelete,
+            page,
+            selectedBlock: block,
+        };
+
+        methods.onNavigatorBlockDelete.call(context, block, section);
+
+        expect(section.blocks.has(block.id)).toBeFalsy();
+        expect($emit).toHaveBeenCalledWith('page-save', true);
+    });
+
+    it('does not save when removing a section from the editor', async () => {
+        const methods = await getMethods();
+        const { page, section } = createPage();
+        const $emit = jest.fn();
+
+        methods.onSectionDelete.call({ $emit, page }, section.id);
+
+        expect(page.sections.has(section.id)).toBeFalsy();
+        expect($emit).not.toHaveBeenCalled();
+    });
+
+    it('saves when removing a section from the navigator', async () => {
+        const methods = await getMethods();
+        const { page, section } = createPage();
+        const $emit = jest.fn();
+        const context = {
+            $emit,
+            onSectionDelete: methods.onSectionDelete,
+            page,
+        };
+
+        methods.onNavigatorSectionDelete.call(context, section.id);
+
+        expect(page.sections.has(section.id)).toBeFalsy();
+        expect($emit).toHaveBeenCalledWith('page-save');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -508,8 +508,17 @@ export default {
                 return true;
             }
 
+            if (this.page.sections.length !== this.pageOrigin.sections.length) {
+                return true;
+            }
+
             for (let i = 0; i < this.page.sections.length; i += 1) {
                 const section = this.page.sections[i];
+                const originSection = this.pageOrigin.sections.get(section.id);
+
+                if (!originSection || section.blocks.length !== originSection.blocks.length) {
+                    return true;
+                }
 
                 if (section._isDirty) {
                     return true;
@@ -517,6 +526,11 @@ export default {
 
                 for (let j = 0; j < section.blocks.length; j += 1) {
                     const block = section.blocks[j];
+                    const originBlock = originSection.blocks.get(block.id);
+
+                    if (!originBlock) {
+                        return true;
+                    }
 
                     if (block._isDirty) {
                         return true;
@@ -524,7 +538,12 @@ export default {
 
                     for (let k = 0; k < block.slots.length; k += 1) {
                         const slot = block.slots[k];
-                        const originSlot = this.pageOrigin.sections.get(section.id).blocks.get(block.id).slots.get(slot.id);
+                        const originSlot = originBlock.slots.get(slot.id);
+
+                        if (!originSlot) {
+                            return true;
+                        }
+
                         const slotDiff = getObjectDiff(originSlot, slot);
 
                         if (slot._isDirty || !isEmpty(slotDiff)) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
@@ -810,6 +810,49 @@ describe('module/sw-cms/page/sw-cms-detail', () => {
         expect(mockProductStore.$reset).toHaveBeenCalledTimes(1);
     });
 
+    it('detects removed CMS sections as unsaved changes', async () => {
+        const wrapper = await createWrapper();
+        const pageOriginSections = new EntityCollection(null, 'cms_section', Shopware.Context.api, null, [
+            {
+                id: 'section-id',
+                blocks: new EntityCollection(null, 'cms_block', Shopware.Context.api, null, []),
+            },
+        ]);
+
+        const page = {
+            _isDirty: false,
+            sections: new EntityCollection(null, 'cms_section', Shopware.Context.api, null, []),
+        };
+
+        expect(
+            wrapper.vm.$options.methods.hasUnsavedChanges.call({ page, pageOrigin: { sections: pageOriginSections } }),
+        ).toBeTruthy();
+    });
+
+    it('detects removed CMS blocks as unsaved changes', async () => {
+        const wrapper = await createWrapper();
+        const pageOriginSections = new EntityCollection(null, 'cms_section', Shopware.Context.api, null, [
+            {
+                id: 'section-id',
+                blocks: new EntityCollection(null, 'cms_block', Shopware.Context.api, null, [{ id: 'block-id', slots: [] }]),
+            },
+        ]);
+
+        const page = {
+            _isDirty: false,
+            sections: new EntityCollection(null, 'cms_section', Shopware.Context.api, null, [
+                {
+                    id: 'section-id',
+                    blocks: new EntityCollection(null, 'cms_block', Shopware.Context.api, null, []),
+                },
+            ]),
+        };
+
+        expect(
+            wrapper.vm.$options.methods.hasUnsavedChanges.call({ page, pageOrigin: { sections: pageOriginSections } }),
+        ).toBeTruthy();
+    });
+
     it('should handle stores that are not registered', async () => {
         const wrapper = await createWrapper();
         await flushPromises();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Deleting CMS blocks or sections through the regular editor persists the change immediately, despite the editor providing an explicit Save action.

Navigator actions intentionally save immediately: after duplication, the cloned associations must be persisted before blocks can reliably be moved or deleted. This was introduced to fix the navigator workflow. The regular editor shares those handlers even though it does not need that compromise.

### 2. What does this change do, exactly?

Splits deletion handling by source:

- Deletions in the regular CMS editor remain unsaved until the user clicks Save and are detected as unsaved changes.
- Navigator deletions continue to save immediately.

Duplicating remains out of scope. It uses server-side clone operations that immediately create the cloned entity and its associations; deferring that safely would require a separate in-memory duplication flow.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create or open an existing CMS layout.
2. Add and save a block or section.
3. Reopen the layout editor.
4. Remove the block or section through its regular configuration.
5. Leave the editor without clicking Save.
6. Reopen the layout and observe that the deletion was persisted despite never saving it.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #18674

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
