### PR TITLE
chore: throwaway PR to inspect commit status rendering

### DIFF
--- a/THROWAWAY-status-probe.md
+++ b/THROWAWAY-status-probe.md
@@ -1,0 +1,4 @@
+# Throwaway
+
+Temporary pull request used to look at how a failing commit status renders.
+Delete together with its branch.


### PR DESCRIPTION
Throwaway. Draft on purpose so no reviews are requested and codeowners stays quiet.

Purpose: look at how a failing **commit status** renders in the checks box, as opposed to a failing check run. A `milestone/label` status will be set to `failure` on the head commit.

Delete this pull request and its branch when done.