### PR TITLE
ci: report the milestone and codeowners verdicts as commit statuses

### DIFF
--- a/.github/bin/js/milestone-label.test.ts
+++ b/.github/bin/js/milestone-label.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { checkMilestoneLabel, evaluateMilestoneLabel, expectedMilestone, MILESTONE_LABEL_PREFIX, SKIP_CHECK_LABEL } from './milestone-label.ts';
+import { checkMilestoneLabel, evaluateMilestoneLabel, expectedMilestone, MILESTONE_LABEL_PREFIX, SKIP_CHECK_LABEL, STATUS_CONTEXT } from './milestone-label.ts';
 
 // The state of shopware/shopware after the 6.7.13.x branch-off: 6.7.13.* is closed,
 // 6.7.14.0 is what trunk collects.
@@ -153,10 +153,12 @@ function mergeGroupToolkit(
     commits: { sha: string; pulls: number[] }[],
     headRef = 'refs/heads/gh-readonly-queue/trunk/pr-18791-0123456789abcdef0123456789abcdef01234567',
 ) {
+    const statuses: { state: string; description: string }[] = [];
     const failed: string[] = [];
     const warnings: string[] = [];
 
     return {
+        statuses,
         failed,
         warnings,
         toolkit: {
@@ -177,6 +179,13 @@ function mergeGroupToolkit(
                         },
                     },
                     repos: {
+                        createCommitStatus: async ({ state, description, context: ctx }: { state: string; description: string; context: string }) => {
+                            assert.equal(ctx, STATUS_CONTEXT);
+                            assert.ok(description.length <= 140, `status description too long: ${description.length}`);
+                            statuses.push({ state, description });
+
+                            return {};
+                        },
                         compareCommitsWithBasehead: async () => ({ data: { commits: commits.map(({ sha }) => ({ sha })) } }),
                         listPullRequestsAssociatedWithCommit: async ({ commit_sha }: { commit_sha: string }) => ({
                             data: (commits.find(({ sha }) => sha === commit_sha)?.pulls ?? []).map((number) => ({ number })),
@@ -206,29 +215,34 @@ function mergeGroupToolkit(
 test('the merge group gate fails a queued PR whose label is already branched', () => {
     // This is the case no pull_request event covers: GitHub retargeted the PR to
     // trunk silently, so the PR-level run never re-evaluated it.
-    const { toolkit, failed } = mergeGroupToolkit(
+    const { toolkit, failed, statuses } = mergeGroupToolkit(
         { 18791: { base: 'trunk', labels: [`${MILESTONE_LABEL_PREFIX}6.7.13.0`] } },
         [{ sha: 'c1', pulls: [18791] }],
     );
 
     return checkMilestoneLabel(toolkit as never).then(() => {
-        assert.equal(failed.length, 1);
-        assert.match(failed[0], /#18791/);
-        assert.match(failed[0], /6\.7\.13\.x` already exists/);
+        // The job stays green; the verdict lives in the commit status.
+        assert.deepEqual(failed, []);
+        assert.equal(statuses.length, 1);
+        assert.equal(statuses[0].state, 'failure');
+        assert.match(statuses[0].description, /is closed for new work/);
     });
 });
 
 test('the merge group gate passes a correctly labelled queued PR', () => {
-    const { toolkit, failed } = mergeGroupToolkit(
+    const { toolkit, failed, statuses } = mergeGroupToolkit(
         { 18791: { base: 'trunk', labels: [`${MILESTONE_LABEL_PREFIX}6.7.14.0`] } },
         [{ sha: 'c1', pulls: [18791] }],
     );
 
-    return checkMilestoneLabel(toolkit as never).then(() => assert.deepEqual(failed, []));
+    return checkMilestoneLabel(toolkit as never).then(() => {
+        assert.deepEqual(failed, []);
+        assert.equal(statuses[0].state, 'success');
+    });
 });
 
 test('the merge group gate checks every PR in a batch, not just the one the ref names', () => {
-    const { toolkit, failed } = mergeGroupToolkit(
+    const { toolkit, failed, statuses } = mergeGroupToolkit(
         {
             18791: { base: 'trunk', labels: [`${MILESTONE_LABEL_PREFIX}6.7.14.0`] },
             18780: { base: 'trunk', labels: [`${MILESTONE_LABEL_PREFIX}6.7.13.0`] },
@@ -237,13 +251,14 @@ test('the merge group gate checks every PR in a batch, not just the one the ref 
     );
 
     return checkMilestoneLabel(toolkit as never).then(() => {
-        assert.equal(failed.length, 1);
-        assert.match(failed[0], /#18780/);
+        assert.equal(statuses[0].state, 'failure');
+        assert.match(statuses[0].description, /#18780/);
+        assert.doesNotMatch(statuses[0].description, /#18791/);
     });
 });
 
 test('the merge group gate still checks the ref-named PR when the commit lookup fails', () => {
-    const { toolkit, failed, warnings } = mergeGroupToolkit(
+    const { toolkit, failed, warnings, statuses } = mergeGroupToolkit(
         { 18791: { base: 'trunk', labels: [`${MILESTONE_LABEL_PREFIX}6.7.13.0`] } },
         [],
     );
@@ -253,7 +268,26 @@ test('the merge group gate still checks the ref-named PR when the commit lookup 
 
     return checkMilestoneLabel(toolkit as never).then(() => {
         assert.equal(warnings.length, 1);
-        assert.equal(failed.length, 1);
-        assert.match(failed[0], /#18791/);
+        assert.equal(statuses[0].state, 'failure');
     });
+});
+
+test('every short form fits the commit status limit', () => {
+    const cases = [
+        [],
+        ['component/core'],
+        [SKIP_CHECK_LABEL],
+        [`${MILESTONE_LABEL_PREFIX}6.7.14.0`],
+        [`${MILESTONE_LABEL_PREFIX}6.7.13.0`],
+        [`${MILESTONE_LABEL_PREFIX}6.7.13.0`, 'backport-6.7.13.x'],
+        [`${MILESTONE_LABEL_PREFIX}6.7.13.0`, `${MILESTONE_LABEL_PREFIX}6.7.14.0`],
+        [`${MILESTONE_LABEL_PREFIX}6.7.x`],
+    ];
+
+    for (const base of ['trunk', '6.7.13.x', 'feat/some-stacked-branch']) {
+        for (const labels of cases) {
+            const { short } = evaluateMilestoneLabel({ baseRefName: base, defaultBranch: 'trunk', labels, versionBranches: VERSION_BRANCHES });
+            assert.ok(short.length <= 140, `too long (${short.length}) for base ${base}: ${short}`);
+        }
+    }
 });

--- a/.github/bin/js/milestone-label.ts
+++ b/.github/bin/js/milestone-label.ts
@@ -23,10 +23,11 @@ const VERSION_BRANCH_PATTERN = /^(\d+\.\d+(?:\.\d+)*)\.x$/;
 /** Matches a full four-segment version as used in milestone labels, e.g. `6.7.13.0`. */
 const MILESTONE_VERSION_PATTERN = /^\d+\.\d+\.\d+\.\d+$/;
 
+/** `message` is the long form for the job summary, `short` the one for the commit status. */
 export type MilestoneVerdict =
-    | { status: 'ok'; message: string }
-    | { status: 'skipped'; message: string }
-    | { status: 'invalid'; message: string; expected?: string };
+    | { status: 'ok'; message: string; short: string }
+    | { status: 'skipped'; message: string; short: string }
+    | { status: 'invalid'; message: string; short: string; expected?: string };
 
 export type MilestoneLabelInput = {
     baseRefName: string;
@@ -88,19 +89,27 @@ function compareSegments(left: number[], right: number[]): number {
 
 export function evaluateMilestoneLabel({ baseRefName, defaultBranch, labels, versionBranches, isDraft = false, labelerPending = false }: MilestoneLabelInput): MilestoneVerdict {
     if (labels.includes(SKIP_CHECK_LABEL)) {
-        return { status: 'skipped', message: `\`${SKIP_CHECK_LABEL}\` is set` };
+        return { status: 'skipped', message: `\`${SKIP_CHECK_LABEL}\` is set`, short: `${SKIP_CHECK_LABEL} is set` };
     }
 
     const milestoneLabels = labels.filter((label) => label.startsWith(MILESTONE_LABEL_PREFIX));
     if (milestoneLabels.length > 1) {
-        return { status: 'invalid', message: `carries ${milestoneLabels.length} milestone labels (${milestoneLabels.join(', ')}), expected exactly one` };
+        return {
+            status: 'invalid',
+            message: `carries ${milestoneLabels.length} milestone labels (${milestoneLabels.join(', ')}), expected exactly one`,
+            short: `${milestoneLabels.length} milestone labels, expected exactly one`,
+        };
     }
 
     const baseLine = releaseLineOf(baseRefName);
 
     // A stacked PR lands wherever its parent merges, so there is nothing to judge yet.
     if (baseRefName !== defaultBranch && baseLine === undefined) {
-        return { status: 'skipped', message: `base branch \`${baseRefName}\` is neither \`${defaultBranch}\` nor a version branch` };
+        return {
+            status: 'skipped',
+            message: `base branch \`${baseRefName}\` is neither \`${defaultBranch}\` nor a version branch`,
+            short: `base ${baseRefName} is neither ${defaultBranch} nor a version branch`,
+        };
     }
 
     const expected = expectedMilestone(versionBranches);
@@ -108,16 +117,25 @@ export function evaluateMilestoneLabel({ baseRefName, defaultBranch, labels, ver
 
     if (label === undefined) {
         if (isDraft) {
-            return { status: 'skipped', message: `is a draft without a \`${MILESTONE_LABEL_PREFIX}*\` label; it gets one when it is marked ready for review` };
+            return {
+                status: 'skipped',
+                message: `is a draft without a \`${MILESTONE_LABEL_PREFIX}*\` label; it gets one when it is marked ready for review`,
+                short: `draft without a ${MILESTONE_LABEL_PREFIX}* label`,
+            };
         }
 
         if (labelerPending) {
-            return { status: 'skipped', message: `has no \`${MILESTONE_LABEL_PREFIX}*\` label yet; the labeler is still running` };
+            return {
+                status: 'skipped',
+                message: `has no \`${MILESTONE_LABEL_PREFIX}*\` label yet; the labeler is still running`,
+                short: `no ${MILESTONE_LABEL_PREFIX}* label yet, the labeler is still running`,
+            };
         }
 
         return {
             status: 'invalid',
             message: `has no \`${MILESTONE_LABEL_PREFIX}*\` label, so it would be released without being announced anywhere`,
+            short: expected ? `no ${MILESTONE_LABEL_PREFIX}* label, set ${MILESTONE_LABEL_PREFIX}${expected}` : `no ${MILESTONE_LABEL_PREFIX}* label`,
             // On a version branch the right patch depends on release state this module cannot see.
             expected: baseLine === undefined ? expected : undefined,
         };
@@ -125,29 +143,42 @@ export function evaluateMilestoneLabel({ baseRefName, defaultBranch, labels, ver
 
     const version = milestoneVersionOf(label);
     if (version === undefined) {
-        return { status: 'invalid', message: `\`${label}\` is not a \`${MILESTONE_LABEL_PREFIX}X.Y.Z.P\` version` };
+        return {
+            status: 'invalid',
+            message: `\`${label}\` is not a \`${MILESTONE_LABEL_PREFIX}X.Y.Z.P\` version`,
+            short: `${label} is not a ${MILESTONE_LABEL_PREFIX}X.Y.Z.P version`,
+        };
     }
 
     if (baseLine !== undefined) {
         return version.startsWith(`${baseLine}.`)
-            ? { status: 'ok', message: `\`${label}\` matches base branch \`${baseRefName}\`` }
-            : { status: 'invalid', message: `\`${label}\` does not belong to base branch \`${baseRefName}\`` };
+            ? { status: 'ok', message: `\`${label}\` matches base branch \`${baseRefName}\``, short: `${label} matches ${baseRefName}` }
+            : { status: 'invalid', message: `\`${label}\` does not belong to base branch \`${baseRefName}\``, short: `${label} does not belong to ${baseRefName}` };
     }
 
     const line = version.split('.').slice(0, 3).join('.');
     if (!versionBranches.includes(`${line}.x`)) {
-        return { status: 'ok', message: `\`${label}\` is still open — branch \`${line}.x\` does not exist yet` };
+        return {
+            status: 'ok',
+            message: `\`${label}\` is still open — branch \`${line}.x\` does not exist yet`,
+            short: `${label} is still open, branch ${line}.x does not exist yet`,
+        };
     }
 
     const backportLabel = `backport-${line}.x`;
     if (labels.includes(backportLabel)) {
-        return { status: 'ok', message: `\`${label}\` is closed for new work, but \`${backportLabel}\` routes this PR into it on purpose` };
+        return {
+            status: 'ok',
+            message: `\`${label}\` is closed for new work, but \`${backportLabel}\` routes this PR into it on purpose`,
+            short: `${label} is closed, but ${backportLabel} routes this PR there`,
+        };
     }
 
     return {
         status: 'invalid',
         message: `\`${label}\` claims the ${line}.* release, but branch \`${line}.x\` already exists — anything merged into \`${defaultBranch}\` now ships later. `
             + `Set \`${MILESTONE_LABEL_PREFIX}${expected ?? '<next version>'}\`, or add \`${backportLabel}\` if this really is meant to be backported into ${line}.x.`,
+        short: `${label} is closed for new work, set ${MILESTONE_LABEL_PREFIX}${expected ?? '<next version>'} or add ${backportLabel}`,
         expected,
     };
 }
@@ -175,6 +206,17 @@ type MergeGroupClient = {
         repos: {
             compareCommitsWithBasehead(options: { owner: string; repo: string; basehead: string }): Promise<{ data: { commits: { sha: string }[] } }>;
             listPullRequestsAssociatedWithCommit(options: { owner: string; repo: string; commit_sha: string }): Promise<{ data: { number: number }[] }>;
+        };
+    };
+};
+
+type StatusClient = {
+    rest: {
+        repos: {
+            createCommitStatus(options: {
+                owner: string; repo: string; sha: string;
+                state: 'success' | 'failure'; context: string; description: string; target_url?: string;
+            }): Promise<unknown>;
         };
     };
 };
@@ -220,6 +262,7 @@ export async function fetchVersionBranches(github: GraphqlClient, { owner, repo 
 type PullRequestPayload = {
     number: number;
     base: { ref: string };
+    head: { sha: string };
     labels?: { name: string }[];
     draft?: boolean;
 };
@@ -242,7 +285,7 @@ type PullRequestContext = {
 };
 
 type Toolkit = {
-    github: GraphqlClient & IssuesClient & MergeGroupClient;
+    github: GraphqlClient & IssuesClient & MergeGroupClient & StatusClient;
     core: Logger;
     context: PullRequestContext;
 };
@@ -331,12 +374,55 @@ async function pullRequestsToCheck({ github, core, context }: Toolkit): Promise<
     }));
 }
 
+export const STATUS_CONTEXT = 'milestone/label';
+
+/** GitHub rejects a longer status description with a 422 rather than truncating it. */
+const STATUS_DESCRIPTION_LIMIT = 140;
+
+function truncate(text: string): string {
+    return text.length <= STATUS_DESCRIPTION_LIMIT ? text : `${text.slice(0, STATUS_DESCRIPTION_LIMIT - 1)}…`;
+}
+
+/** The commit the status belongs to: the merge group for the queue, the head otherwise. */
+function statusShaOf(context: PullRequestContext): string {
+    const mergeGroup = context.payload.merge_group;
+
+    return context.eventName === 'merge_group' && mergeGroup ? mergeGroup.head_sha : pullRequestOf(context).head.sha;
+}
+
+/** The only link a commit status carries, so point it at the run holding the long form. */
+function runUrl({ owner, repo }: Repo): string | undefined {
+    const server = process.env.GITHUB_SERVER_URL;
+    const runId = process.env.GITHUB_RUN_ID;
+
+    return server && runId ? `${server}/${owner}/${repo}/actions/runs/${runId}` : undefined;
+}
+
 /**
- * Fails the run when a milestone label contradicts its base branch.
+ * Reports the verdict as a commit status instead of failing the job.
  *
+ * A failed check run is bound to its check suite and every run creates a new one, so
+ * a red result survives on the commit even after the label is fixed. A commit status
+ * is keyed by context: the next run overwrites it and the pull request turns green
+ * without a new commit.
+ */
+async function postVerdictStatus(toolkit: Toolkit, state: 'success' | 'failure', description: string): Promise<void> {
+    const { github, context } = toolkit;
+    const target = runUrl(context.repo);
+
+    await github.rest.repos.createCommitStatus({
+        ...context.repo,
+        sha: statusShaOf(context),
+        state,
+        context: STATUS_CONTEXT,
+        description: truncate(description),
+        ...(target ? { target_url: target } : {}),
+    });
+}
+
+/**
  * `merge_group` is the gate that matters: it is always evaluated against the final
  * base, while the `pull_request` run can be green from before a silent retarget.
- * Reports only, so a check never changes what it is checking.
  */
 export async function checkMilestoneLabel(toolkit: Toolkit): Promise<void> {
     const { github, core, context } = toolkit;
@@ -344,34 +430,37 @@ export async function checkMilestoneLabel(toolkit: Toolkit): Promise<void> {
     const versionBranches = await fetchVersionBranches(github, context.repo);
     const pullRequests = await pullRequestsToCheck(toolkit);
 
-    const summary: string[] = [];
-    const failures: string[] = [];
-
-    for (const pullRequest of pullRequests) {
-        const verdict = evaluateMilestoneLabel({
+    const judged = pullRequests.map((pullRequest) => ({
+        pullRequest,
+        verdict: evaluateMilestoneLabel({
             baseRefName: pullRequest.baseRefName,
             defaultBranch,
             labels: pullRequest.labels,
             versionBranches,
             isDraft: pullRequest.isDraft,
             labelerPending: pullRequest.labelerPending,
-        });
+        }),
+    }));
 
-        const icon = { ok: '✅', skipped: '➖', invalid: '❌' }[verdict.status];
-        summary.push(`${icon} #${pullRequest.number} ${verdict.message}`);
-
-        if (verdict.status === 'invalid') {
-            failures.push(`PR #${pullRequest.number} ${verdict.message}`);
-        } else {
-            core.info(`PR #${pullRequest.number} ${verdict.message}`);
-        }
+    for (const { pullRequest, verdict } of judged) {
+        core.info(`PR #${pullRequest.number} ${verdict.message}`);
     }
 
-    await core.summary.addRaw(`## Milestone label\n\n${summary.map((line) => `- ${line}`).join('\n')}\n`).write();
+    const summary = judged.map(({ pullRequest, verdict }) =>
+        `- ${{ ok: '✅', skipped: '➖', invalid: '❌' }[verdict.status]} #${pullRequest.number} ${verdict.message}`);
+    await core.summary.addRaw(`## Milestone label\n\n${summary.join('\n')}\n`).write();
 
-    if (failures.length > 0) {
-        core.setFailed(failures.join('\n'));
-    }
+    const invalid = judged.filter(({ verdict }) => verdict.status === 'invalid');
+
+    // A single pull request speaks for itself; a batched merge group has to name the
+    // offenders, because the status is the only thing the queue shows.
+    const description = judged.length === 1
+        ? judged[0].verdict.short
+        : invalid.length === 0
+            ? `all ${judged.length} queued pull requests carry a valid milestone label`
+            : invalid.map(({ pullRequest, verdict }) => `#${pullRequest.number} ${verdict.short}`).join('; ');
+
+    await postVerdictStatus(toolkit, invalid.length === 0 ? 'success' : 'failure', description);
 }
 
 /**

--- a/.github/workflows/codeowner.yml
+++ b/.github/workflows/codeowner.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  statuses: write
 
 jobs:
   codeowners:
@@ -40,10 +41,33 @@ jobs:
           scope: shopware
           identity: CodeownersPlus
 
+      # Approvals arrive without a new commit, and a failed check run can never be
+      # superseded on the same commit. The verdict therefore goes into the
+      # `codeowners/approvals` status — require that context, not this job name.
       - name: 'Codeowners Plus'
+        id: codeowners
+        continue-on-error: true
         uses: multimediallc/codeowners-plus@492316f7b626694d8e43813585364ce6fab6d579 # v1.10.0
         with:
           github-token: '${{ steps.sts.outputs.token }}'
           pr: '${{ github.event.pull_request.number }}'
           verbose: true
           quiet: ${{ github.event.pull_request.draft }}
+
+      - name: 'Report approvals as a commit status'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          APPROVED: ${{ steps.codeowners.outcome == 'success' }}
+        with:
+          script: |
+            const approved = process.env.APPROVED === 'true'
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: approved ? 'success' : 'failure',
+              context: 'codeowners/approvals',
+              description: approved
+                ? 'All required code owners approved'
+                : 'Approvals from required code owners are still missing',
+              target_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+            })

--- a/.github/workflows/milestone-check.yml
+++ b/.github/workflows/milestone-check.yml
@@ -1,10 +1,11 @@
 name: Check milestone label
 # Rule and reasoning: .github/bin/js/milestone-label.ts
 #
-# merge_group is the gate that matters — GitHub retargets a stacked PR to trunk
-# without emitting a pull_request event, so the PR-level run can be green from
-# before the retarget. Both report the same job name, so one required check covers
-# the PR and the queue.
+# Require the `milestone/label` commit status in branch protection and the merge
+# queue, not this job name — the job stays green by design.
+#
+# merge_group is the gate that matters: GitHub retargets a stacked PR to trunk without
+# emitting a pull_request event, so the PR-level run can be green from before it.
 
 on:
   pull_request:
@@ -21,6 +22,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  statuses: write
 
 jobs:
   check:
@@ -51,3 +53,17 @@ jobs:
           script: |
             const { checkMilestoneLabel } = await import('${{ github.workspace }}/.github/bin/js/milestone-label.ts')
             await checkMilestoneLabel({ github, core, context })
+
+      # A required status context that is never reported blocks the pull request
+      # forever, so the branches without the rule have to report too.
+      - if: steps.rule.outputs.present != 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: context.payload.pull_request?.head.sha ?? context.payload.merge_group.head_sha,
+              state: 'success',
+              context: 'milestone/label',
+              description: 'no milestone label rule on this base branch',
+            })


### PR DESCRIPTION
### 1. Why is this change necessary?

Labels and approvals change without a new commit, but a failed check run can never be superseded on the same commit — it belongs to a check suite and every run creates a new one. The red one stays forever, see #18953.

### 2. What does this change do, exactly?

Both jobs stay green and report their verdict as a commit status, `milestone/label` and `codeowners/approvals`, which the next run overwrites. Require those contexts rather than the job names.

### 3. Describe each step to reproduce the issue or behaviour.

Set a wrong milestone label, wait for the red status, correct the label: it turns green on the same commit.

### 4. Please link to the relevant issues (if any).

Follows up on #18845 and #18940.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
