### PR TITLE
fix(storefront): remove redundant logo title

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/header/logo.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/logo.html.twig
@@ -2,8 +2,7 @@
     <div class="header-logo-main text-center">
         {% block layout_header_logo_link %}
             <a class="header-logo-main-link"
-               href="{{ path('frontend.home.page') }}"
-               title="{{ 'header.logoLink'|trans|striptags }}">
+               href="{{ path('frontend.home.page') }}">
                 {% block layout_header_logo_image %}
                     <picture class="header-logo-picture d-block m-auto">
                         {% block layout_header_logo_image_tablet %}


### PR DESCRIPTION
### 1. Why is this change necessary?

* The linked Header logo has duplicate title and alt attribute.

### 2. What does this change do, exactly?

* Removing the title attribute because it is redundant. With the linked image, the link gets it's "label" from the alt attribute of the image itself. 
* See W3C suggestion about functional images: https://www.w3.org/WAI/tutorials/images/functional/#example-1-image-used-alone-as-a-linked-logo

### 3. Describe each step to reproduce the issue or behaviour.

* Activate the screenreader
* Navigate to the Logo
* It should be announced as "Link - Go to homepage"

### 4. Please link to the relevant issues (if any).

- closes #10527





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the translated title attribute from the header logo link to provide a cleaner, more consistent navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->