### PR TITLE
ci: run the milestone check as pull_request_target for fork PRs

### DIFF
--- a/.github/bin/js/milestone-label.test.ts
+++ b/.github/bin/js/milestone-label.test.ts
@@ -212,6 +212,66 @@ function mergeGroupToolkit(
     };
 }
 
+/** Toolkit stub for the single pull-request path (pull_request_target / merge_group's sibling). */
+function pullRequestToolkit(eventName: string, pull: { base: string; labels: string[]; draft?: boolean; sha?: string }) {
+    const statuses: { state: string; description: string }[] = [];
+
+    return {
+        statuses,
+        toolkit: {
+            github: {
+                graphql: async () => ({
+                    repository: { refs: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: VERSION_BRANCHES.map((name) => ({ name })) } },
+                }),
+                rest: {
+                    repos: {
+                        createCommitStatus: async ({ state, description, context: ctx }: { state: string; description: string; context: string }) => {
+                            assert.equal(ctx, STATUS_CONTEXT);
+                            statuses.push({ state, description });
+
+                            return {};
+                        },
+                    },
+                },
+            },
+            core: {
+                info: () => {},
+                warning: () => {},
+                error: () => {},
+                setFailed: () => { throw new Error('the job must stay green; the verdict belongs in the commit status'); },
+                summary: { addRaw: () => ({ write: async () => {} }) },
+            },
+            context: {
+                eventName,
+                repo: { owner: 'shopware', repo: 'shopware' },
+                payload: {
+                    repository: { default_branch: 'trunk' },
+                    pull_request: { number: 1, base: { ref: pull.base }, head: { sha: pull.sha ?? 'cccc' }, draft: pull.draft ?? false, labels: pull.labels.map((name) => ({ name })) },
+                },
+            },
+        },
+    };
+}
+
+// Locks in "anything but merge_group" rather than a literal event-name check.
+for (const eventName of ['pull_request_target', 'pull_request']) {
+    test(`the single-PR path posts the commit status on a "${eventName}" event`, async () => {
+        const { toolkit, statuses } = pullRequestToolkit(eventName, { base: 'trunk', labels: [`${MILESTONE_LABEL_PREFIX}6.7.13.0`] });
+
+        await checkMilestoneLabel(toolkit as never);
+
+        assert.equal(statuses.length, 1);
+        assert.equal(statuses[0].state, 'failure');
+    });
+}
+
+test('the single-PR path never fails the job, even when the label is wrong', async () => {
+    const { toolkit } = pullRequestToolkit('pull_request_target', { base: 'trunk', labels: [] });
+
+    // pullRequestToolkit's setFailed throws — reaching it would fail this test.
+    await checkMilestoneLabel(toolkit as never);
+});
+
 test('the merge group gate fails a queued PR whose label is already branched', () => {
     // This is the case no pull_request event covers: GitHub retargeted the PR to
     // trunk silently, so the PR-level run never re-evaluated it.

--- a/.github/bin/js/milestone-label.ts
+++ b/.github/bin/js/milestone-label.ts
@@ -422,7 +422,7 @@ async function postVerdictStatus(toolkit: Toolkit, state: 'success' | 'failure',
 
 /**
  * `merge_group` is the gate that matters: it is always evaluated against the final
- * base, while the `pull_request` run can be green from before a silent retarget.
+ * base, while the pull-request-level run can be green from before a silent retarget.
  */
 export async function checkMilestoneLabel(toolkit: Toolkit): Promise<void> {
     const { github, core, context } = toolkit;

--- a/.github/workflows/milestone-check.yml
+++ b/.github/workflows/milestone-check.yml
@@ -6,9 +6,14 @@ name: Check milestone label
 #
 # merge_group is the gate that matters: GitHub retargets a stacked PR to trunk without
 # emitting a pull_request event, so the PR-level run can be green from before it.
+#
+# pull_request_target, not pull_request: a fork PR's GITHUB_TOKEN is read-only on
+# pull_request no matter the permissions block, so posting the status 403'd on the
+# pull requests this most needs to run on (#18741). Safe here because the job never
+# checks out or executes the PR head, only the base ref and PR metadata via the API.
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
### 1. Why is this change necessary?

#18741 is a fork PR. A fork's `GITHUB_TOKEN` is read-only on `pull_request` regardless of the permissions block, so `createCommitStatus` 403'd — a regression from #18980, on exactly the pull requests this check most needs to run on.

### 2. What does this change do, exactly?

Switches the trigger to `pull_request_target`, which gets full write access. Safe here because the job never checks out or executes the PR head, only the base ref's `.github/bin/js` and PR metadata via the API — unchanged from before.

### 3. Describe each step to reproduce the issue or behaviour.

Push to a fork PR against trunk: the `Milestone label` job 403'd on `createCommitStatus` instead of posting the status.

### 4. Please link to the relevant issues (if any).

Fixes a regression from #18980.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved milestone checks for pull requests, including those originating from forks.
  * Invalid milestone labels now report a failed commit status without directly failing the workflow job.
  * Improved handling when a pull request’s target branch changes silently.

* **Documentation**
  * Clarified workflow behavior for merge groups and pull request retargeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->