### PR TITLE
ci: make milestone and codeowners checks work for fork pull requests

### DIFF
--- a/.github/workflows/codeowner.yml
+++ b/.github/workflows/codeowner.yml
@@ -18,6 +18,10 @@ permissions:
 jobs:
   codeowners:
     name: 'Run Codeowners Plus'
+    # pull_request_review carries no OIDC token for fork PRs, so the sts mint below
+    # cannot work there; fork PRs are re-evaluated on their next synchronize through
+    # the pull_request_target events instead
+    if: github.event_name != 'pull_request_review' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Code Repository'

--- a/.github/workflows/milestone-check.yml
+++ b/.github/workflows/milestone-check.yml
@@ -6,9 +6,13 @@ name: Check milestone label
 #
 # merge_group is the gate that matters: GitHub retargets a stacked PR to trunk without
 # emitting a pull_request event, so the PR-level run can be green from before it.
+#
+# pull_request_target instead of pull_request: fork PRs get a read-only token on
+# pull_request, so the status write would fail. Safe here because the job only ever
+# checks out the base ref and runs the rule module from it.
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
### 1. Why is this change necessary?

Both PR-gate workflows fail unconditionally on pull requests from forks, observed on #18878:

- **Milestone label** ([job](https://github.com/shopware/shopware/actions/runs/30990281750/job/92254514622)): `pull_request` events from forks carry a read-only `GITHUB_TOKEN`; the `statuses: write` permission cannot elevate it, so publishing the `milestone/label` commit status throws `Resource not accessible by integration`.
- **Run Codeowners Plus** ([job](https://github.com/shopware/shopware/actions/runs/30990519794/job/92255296081)): the `pull_request_review` event carries no OIDC token at all for fork PRs, so the octo-sts mint fails with "Missing required environment variables" regardless of `id-token: write`.

### 2. What does this change do, exactly?

- `milestone-check.yml` triggers on `pull_request_target` instead of `pull_request`, which runs in base-repo context with a working token for fork PRs too. This is safe by the workflow's existing construction: it only ever checks out the base ref (sparse, `.github/bin/js`) and runs the rule module from it, so no fork code executes with the elevated token.
- `codeowner.yml` skips the job for the fork-PR + `pull_request_review` combination, where minting is structurally impossible. Fork PRs are still evaluated through the `pull_request_target` events; an approval-triggered re-evaluation happens on their next synchronize. Same-repo PRs keep the immediate review-event refresh.

### 3. Describe each step to reproduce the issue or behaviour.

Open a PR from a fork: the Milestone label job fails on the status write, and any submitted review fails the Codeowners Plus job on the token mint.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated pull request checks for forked contributions.
  * Maintained milestone and code ownership checks across supported pull request events.
  * Added workflow guidance for read-only checkout and base-branch execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->