### PR TITLE
ci: relay fork PR review approvals through a privileged handler

### DIFF
--- a/.github/actions/codeowners-plus-status/action.yaml
+++ b/.github/actions/codeowners-plus-status/action.yaml
@@ -1,0 +1,55 @@
+name: 'Codeowners Plus with commit status'
+description: 'Runs codeowners-plus for a pull request and reports codeowners/approvals as a commit status.'
+
+inputs:
+  pr-number:
+    description: 'Pull request number'
+    required: true
+  draft:
+    description: 'Whether the pull request is a draft'
+    required: true
+  head-sha:
+    description: 'Commit the status is reported on'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: git fetch --no-tags origin "pull/${{ inputs.pr-number }}/head"
+
+    # GITHUB_TOKEN has no organization scope, so requesting a review from a team
+    # fails with "Could not resolve to a node with the global id of 'T_…'". No
+    # fallback on purpose: falling back would silently reintroduce that failure.
+    - id: sts
+      uses: shopware/octo-sts-action@main
+      with:
+        scope: shopware
+        identity: CodeownersPlus
+
+    - id: codeowners
+      continue-on-error: true
+      uses: multimediallc/codeowners-plus@492316f7b626694d8e43813585364ce6fab6d579 # v1.10.0
+      with:
+        github-token: '${{ steps.sts.outputs.token }}'
+        pr: '${{ inputs.pr-number }}'
+        verbose: true
+        quiet: ${{ inputs.draft }}
+
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      env:
+        APPROVED: ${{ steps.codeowners.outcome == 'success' }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+      with:
+        script: |
+          const approved = process.env.APPROVED === 'true'
+          await github.rest.repos.createCommitStatus({
+            ...context.repo,
+            sha: process.env.HEAD_SHA,
+            state: approved ? 'success' : 'failure',
+            context: 'codeowners/approvals',
+            description: approved
+              ? 'All required code owners approved'
+              : 'Approvals from required code owners are still missing',
+            target_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+          })

--- a/.github/workflows/codeowner-fork-review-handler.yml
+++ b/.github/workflows/codeowner-fork-review-handler.yml
@@ -1,0 +1,59 @@
+name: 'Code Owners (fork review handler)'
+# Uses the PR number codeowner-fork-review-relay.yml recorded. workflow_run always
+# runs the workflow file from the default branch, so a PR cannot alter what this does.
+
+on:
+  workflow_run:
+    workflows: ['Code Owners (fork review trigger)']
+    types: [completed]
+
+permissions:
+  contents: read
+  id-token: write
+  statuses: write
+  actions: read
+
+jobs:
+  handle:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: codeowners-fork-review-pr
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # The artifact only ever holds a plain PR number (see the trigger workflow),
+      # but the number is re-validated here rather than trusted blindly.
+      - id: pr-number
+        run: |
+          number="$(tr -d '[:space:]' < pr-number.txt)"
+          if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr-number.txt did not contain a plain integer: $number"
+            exit 1
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      # The artifact's number identifies the PR; its current head, base and draft
+      # state are re-fetched here rather than trusted from the (older) review event.
+      - id: pr
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number: Number(process.env.PR_NUMBER) })
+            core.setOutput('head-sha', pr.head.sha)
+            core.setOutput('draft', String(pr.draft))
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/codeowners-plus-status
+        with:
+          pr-number: ${{ steps.pr-number.outputs.number }}
+          draft: ${{ steps.pr.outputs.draft }}
+          head-sha: ${{ steps.pr.outputs.head-sha }}

--- a/.github/workflows/codeowner-fork-review-relay.yml
+++ b/.github/workflows/codeowner-fork-review-relay.yml
@@ -1,0 +1,24 @@
+name: 'Code Owners (fork review trigger)'
+# A fork PR's GITHUB_TOKEN has no OIDC on pull_request_review, and there is no
+# pull_request_review_target, so codeowner-fork-review-handler.yml runs privileged
+# instead via workflow_run — whose `pull_requests` field is empty for fork PRs, hence
+# relaying the number as an artifact (github.event.pull_request.number is GitHub's own
+# metadata, not attacker-controlled).
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  relay:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: codeowners-fork-review-pr
+          path: pr-number.txt
+          retention-days: 1

--- a/.github/workflows/codeowner.yml
+++ b/.github/workflows/codeowner.yml
@@ -19,6 +19,8 @@ jobs:
   codeowners:
     name: 'Run Codeowners Plus'
     runs-on: ubuntu-latest
+    # Fork PR reviews cannot mint a token here — see codeowner-fork-review-relay.yml.
+    if: github.event_name != 'pull_request_review' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: 'Checkout Code Repository'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,48 +28,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: 'Fetch PR head'
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: git fetch --no-tags origin "pull/${PR_NUMBER}/head"
-
-      # GITHUB_TOKEN has no organization scope, so requesting a review from a team
-      # fails with "Could not resolve to a node with the global id of 'T_…'". No
-      # fallback on purpose: falling back would silently reintroduce that failure.
-      - name: 'Mint token'
-        id: sts
-        uses: shopware/octo-sts-action@main
+      - uses: ./.github/actions/codeowners-plus-status
         with:
-          scope: shopware
-          identity: CodeownersPlus
-
-      # Approvals arrive without a new commit, and a failed check run can never be
-      # superseded on the same commit. The verdict therefore goes into the
-      # `codeowners/approvals` status — require that context, not this job name.
-      - name: 'Codeowners Plus'
-        id: codeowners
-        continue-on-error: true
-        uses: multimediallc/codeowners-plus@492316f7b626694d8e43813585364ce6fab6d579 # v1.10.0
-        with:
-          github-token: '${{ steps.sts.outputs.token }}'
-          pr: '${{ github.event.pull_request.number }}'
-          verbose: true
-          quiet: ${{ github.event.pull_request.draft }}
-
-      - name: 'Report approvals as a commit status'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          APPROVED: ${{ steps.codeowners.outcome == 'success' }}
-        with:
-          script: |
-            const approved = process.env.APPROVED === 'true'
-            await github.rest.repos.createCommitStatus({
-              ...context.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: approved ? 'success' : 'failure',
-              context: 'codeowners/approvals',
-              description: approved
-                ? 'All required code owners approved'
-                : 'Approvals from required code owners are still missing',
-              target_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
-            })
+          pr-number: ${{ github.event.pull_request.number }}
+          draft: ${{ github.event.pull_request.draft }}
+          head-sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
### 1. Why is this change necessary?

An approval on a fork PR never refreshed `codeowners/approvals` (#18980): a fork's token has no OIDC on `pull_request_review`, and there is no `pull_request_review_target`.

### 2. What does this change do, exactly?

A low-permission trigger records the PR number as an artifact; a `workflow_run` handler picks it up with full permissions and reports the status. Shared logic moved into `.github/actions/codeowners-plus-status`.

### 3. Describe each step to reproduce the issue or behaviour.

Approve a fork PR without a new commit: `codeowners/approvals` now turns green instead of staying on the last push's result.

### 4. Please link to the relevant issues (if any).

Follows up on #18980.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated code-owner review handling for pull requests from forked repositories.
  * Added status reporting for code-owner approval checks.
  * Added workflows to relay review events and process pull request metadata securely.

* **Bug Fixes**
  * Improved review workflow behavior by skipping unsupported fork events and refreshing pull request status before checks run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->