### PR TITLE
fix: protect user uniqueness validation endpoints

### DIFF
--- a/changelog/_unreleased/2026-08-05-enforce-acl-on-user-validation-endpoints.md
+++ b/changelog/_unreleased/2026-08-05-enforce-acl-on-user-validation-endpoints.md
@@ -1,0 +1,6 @@
+---
+title: User validation endpoints now require ACL privileges
+issue:
+---
+# API
+* Changed the user email and username uniqueness validation endpoints to require the `user:read` privilege. Requests with tokens lacking this privilege now receive a `403` response.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3536,11 +3536,6 @@ parameters:
 			path: src/Core/System/User/Aggregate/UserConfig/UserConfigEntity.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\System\\\\User\\\\UserException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
-			count: 4
-			path: src/Core/System/User/Api/UserValidationController.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\System\\\\User\\\\UserCollection\\:\\:getLocaleIds\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/System/User/UserCollection.php

--- a/src/Core/System/User/Api/UserValidationController.php
+++ b/src/Core/System/User/Api/UserValidationController.php
@@ -4,8 +4,9 @@ namespace Shopware\Core\System\User\Api;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Routing\RoutingException;
+use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\User\Service\UserValidationService;
+use Shopware\Core\System\User\UserException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,15 +23,20 @@ class UserValidationController extends AbstractController
     {
     }
 
-    #[Route(path: 'api/_action/user/check-email-unique', name: 'api.action.check-email-unique', methods: ['POST'])]
+    #[Route(
+        path: 'api/_action/user/check-email-unique',
+        name: 'api.action.check-email-unique',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['user:read']],
+        methods: [Request::METHOD_POST]
+    )]
     public function isEmailUnique(Request $request, Context $context): JsonResponse
     {
         if (!$request->request->has('email')) {
-            throw RoutingException::missingRequestParameter('email');
+            throw UserException::missingRequestParameter('email');
         }
 
         if (!$request->request->has('id')) {
-            throw RoutingException::missingRequestParameter('id');
+            throw UserException::missingRequestParameter('id');
         }
 
         $email = (string) $request->request->get('email');
@@ -41,15 +47,20 @@ class UserValidationController extends AbstractController
         );
     }
 
-    #[Route(path: 'api/_action/user/check-username-unique', name: 'api.action.check-username-unique', methods: ['POST'])]
+    #[Route(
+        path: 'api/_action/user/check-username-unique',
+        name: 'api.action.check-username-unique',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['user:read']],
+        methods: [Request::METHOD_POST]
+    )]
     public function isUsernameUnique(Request $request, Context $context): JsonResponse
     {
         if (!$request->request->has('username')) {
-            throw RoutingException::missingRequestParameter('username');
+            throw UserException::missingRequestParameter('username');
         }
 
         if (!$request->request->has('id')) {
-            throw RoutingException::missingRequestParameter('id');
+            throw UserException::missingRequestParameter('id');
         }
 
         $username = (string) $request->request->get('username');

--- a/src/Core/System/User/UserException.php
+++ b/src/Core/System/User/UserException.php
@@ -9,7 +9,18 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('fundamentals@framework')]
 class UserException extends HttpException
 {
+    public const MISSING_REQUEST_PARAMETER_CODE = 'SYSTEM_USER__MISSING_REQUEST_PARAMETER';
     final public const SALES_CHANNEL_NOT_FOUND = 'USER__SALES_CHANNEL_NOT_FOUND';
+
+    public static function missingRequestParameter(string $name, string $path = ''): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::MISSING_REQUEST_PARAMETER_CODE,
+            'Parameter "{{ parameterName }}" is missing.',
+            ['parameterName' => $name, 'path' => $path]
+        );
+    }
 
     public static function salesChannelNotFound(): HttpException
     {

--- a/tests/unit/Core/System/User/Api/UserValidationControllerTest.php
+++ b/tests/unit/Core/System/User/Api/UserValidationControllerTest.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\User\Api;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\User\Api\UserValidationController;
+use Shopware\Core\System\User\Service\UserValidationService;
+use Shopware\Core\System\User\UserException;
+use Symfony\Bundle\FrameworkBundle\Routing\AttributeRouteControllerLoader;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@framework')]
+#[CoversClass(UserValidationController::class)]
+class UserValidationControllerTest extends TestCase
+{
+    /**
+     * @param list<string> $expectedPrivileges
+     */
+    #[DataProvider('aclProtectedRouteProvider')]
+    public function testValidationRoutesRequireUserReadPrivilege(string $routeName, array $expectedPrivileges): void
+    {
+        $route = (new AttributeRouteControllerLoader())->load(UserValidationController::class)->get($routeName);
+
+        static::assertNotNull($route);
+        static::assertSame($expectedPrivileges, $route->getDefault(PlatformRequest::ATTRIBUTE_ACL));
+    }
+
+    /**
+     * @param array<string, string> $payload
+     */
+    #[DataProvider('missingEmailParameterProvider')]
+    public function testEmailValidationRejectsMissingParameters(array $payload, string $missingParameter): void
+    {
+        $controller = new UserValidationController(static::createStub(UserValidationService::class));
+
+        static::expectExceptionObject(UserException::missingRequestParameter($missingParameter));
+
+        $controller->isEmailUnique(
+            Request::create('/', Request::METHOD_POST, $payload),
+            Context::createDefaultContext(),
+        );
+    }
+
+    /**
+     * @param array<string, string> $payload
+     */
+    #[DataProvider('missingUsernameParameterProvider')]
+    public function testUsernameValidationRejectsMissingParameters(array $payload, string $missingParameter): void
+    {
+        $controller = new UserValidationController(static::createStub(UserValidationService::class));
+
+        static::expectExceptionObject(UserException::missingRequestParameter($missingParameter));
+
+        $controller->isUsernameUnique(
+            Request::create('/', Request::METHOD_POST, $payload),
+            Context::createDefaultContext(),
+        );
+    }
+
+    /**
+     * @return \Generator<string, array{0: string, 1: list<string>}>
+     */
+    public static function aclProtectedRouteProvider(): \Generator
+    {
+        yield 'email uniqueness validation' => ['api.action.check-email-unique', ['user:read']];
+        yield 'username uniqueness validation' => ['api.action.check-username-unique', ['user:read']];
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<string, string>, 1: string}>
+     */
+    public static function missingEmailParameterProvider(): \Generator
+    {
+        yield 'email is missing' => [['id' => 'id'], 'email'];
+        yield 'email id is missing' => [['email' => 'email'], 'id'];
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<string, string>, 1: string}>
+     */
+    public static function missingUsernameParameterProvider(): \Generator
+    {
+        yield 'username is missing' => [['id' => 'id'], 'username'];
+        yield 'username id is missing' => [['username' => 'username'], 'id'];
+    }
+}

--- a/tests/unit/Core/System/User/UserExceptionTest.php
+++ b/tests/unit/Core/System/User/UserExceptionTest.php
@@ -25,4 +25,17 @@ class UserExceptionTest extends TestCase
         static::assertSame('No sales channel found.', $exception->getMessage());
         static::assertEmpty($exception->getParameters());
     }
+
+    public function testMissingRequestParameter(): void
+    {
+        $exception = UserException::missingRequestParameter('email', 'user.email');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(UserException::MISSING_REQUEST_PARAMETER_CODE, $exception->getErrorCode());
+        static::assertSame('Parameter "email" is missing.', $exception->getMessage());
+        static::assertSame([
+            'parameterName' => 'email',
+            'path' => 'user.email',
+        ], $exception->getParameters());
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The user email and username uniqueness validation endpoints were not protected by the required ACL privilege.

### 2. What does this change do, exactly?

Requires `user:read` for both validation endpoints and uses the user domain exception for missing request parameters. Adds focused unit coverage and a legacy changelog entry for the 6.6 branch.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create an Administration API token without `user:read`.
2. Call either user uniqueness validation endpoint.
3. The request is denied by ACL.

### 4. Please link to the relevant issues (if any).

Backport of #18931.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a changelog file with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.