### PR TITLE
fix(core): apply review visibility filter to nested product criteria

### DIFF
--- a/src/Core/Content/Product/SalesChannel/SalesChannelProductDefinition.php
+++ b/src/Core/Content/Product/SalesChannel/SalesChannelProductDefinition.php
@@ -49,6 +49,18 @@ class SalesChannelProductDefinition extends ProductDefinition implements SalesCh
             );
         }
 
+        // must be applied on every nesting level, otherwise reviews that are still pending moderation
+        // leak through nested associations that re-enter the product entity (e.g. `children`)
+        if ($criteria->hasAssociation('productReviews')) {
+            $association = $criteria->getAssociation('productReviews');
+            $activeReviewsFilter = new MultiFilter(MultiFilter::CONNECTION_OR, [new EqualsFilter('status', true)]);
+            if ($customer = $context->getCustomer()) {
+                $activeReviewsFilter->addQuery(new EqualsFilter('customerId', $customer->getId()));
+            }
+
+            $association->addFilter($activeReviewsFilter);
+        }
+
         if ($criteria->getNestingLevel() !== Criteria::ROOT_NESTING_LEVEL) {
             return;
         }
@@ -61,16 +73,6 @@ class SalesChannelProductDefinition extends ProductDefinition implements SalesCh
                 ->addAssociation('cover.media')
                 ->addAssociation('tax')
             ;
-        }
-
-        if ($criteria->hasAssociation('productReviews')) {
-            $association = $criteria->getAssociation('productReviews');
-            $activeReviewsFilter = new MultiFilter(MultiFilter::CONNECTION_OR, [new EqualsFilter('status', true)]);
-            if ($customer = $context->getCustomer()) {
-                $activeReviewsFilter->addQuery(new EqualsFilter('customerId', $customer->getId()));
-            }
-
-            $association->addFilter($activeReviewsFilter);
         }
     }
 

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductListRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductListRouteTest.php
@@ -182,6 +182,93 @@ class ProductListRouteTest extends TestCase
         static::assertSame('test public review', $reviews[0]['title']);
     }
 
+    public function testListingProductsIncludesOnlyPublicReviewsWhenNestedBelowChildren(): void
+    {
+        $product = (new ProductBuilder($this->ids, 'p1'))
+            ->visibility($this->ids->get('sales-channel'))
+            ->price(10)
+            ->variant(
+                (new ProductBuilder($this->ids, 'p1.1'))
+                    ->visibility($this->ids->get('sales-channel'))
+                    ->price(10)
+                    ->review('test public review', 'this is a public review', 3, $this->ids->get('sales-channel'))
+                    ->review('test hidden review', 'this is a hidden review', 0, $this->ids->get('sales-channel'), Defaults::LANGUAGE_SYSTEM, false)
+                    ->build()
+            )
+            ->build();
+
+        static::getContainer()->get('product.repository')
+            ->upsert([$product], Context::createDefaultContext());
+
+        $this->browser->request(
+            'POST',
+            '/store-api/product',
+            [
+                'ids' => [$this->ids->get('p1')],
+                'associations' => [
+                    'children' => [
+                        'associations' => [
+                            'productReviews' => [],
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $response = json_decode($this->getResponseContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(1, $response['total']);
+        static::assertArrayHasKey('children', $response['elements'][0]);
+        static::assertCount(1, $response['elements'][0]['children']);
+
+        $reviews = $response['elements'][0]['children'][0]['productReviews'];
+        static::assertCount(1, $reviews);
+        static::assertSame('test public review', $reviews[0]['title']);
+    }
+
+    public function testListingProductsIncludesOnlyPublicReviewsWhenNestedBelowAnyProductAssociation(): void
+    {
+        $canonical = (new ProductBuilder($this->ids, 'p2'))
+            ->visibility($this->ids->get('sales-channel'))
+            ->price(10)
+            ->review('test public review', 'this is a public review', 3, $this->ids->get('sales-channel'))
+            ->review('test hidden review', 'this is a hidden review', 0, $this->ids->get('sales-channel'), Defaults::LANGUAGE_SYSTEM, false)
+            ->build();
+
+        $product = (new ProductBuilder($this->ids, 'p1'))
+            ->visibility($this->ids->get('sales-channel'))
+            ->price(10)
+            ->add('canonicalProductId', $this->ids->get('p2'))
+            ->build();
+
+        static::getContainer()->get('product.repository')
+            ->upsert([$canonical, $product], Context::createDefaultContext());
+
+        $this->browser->request(
+            'POST',
+            '/store-api/product',
+            [
+                'ids' => [$this->ids->get('p1')],
+                'associations' => [
+                    'canonicalProduct' => [
+                        'associations' => [
+                            'productReviews' => [],
+                        ],
+                    ],
+                ],
+            ],
+        );
+
+        $response = json_decode($this->getResponseContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(1, $response['total']);
+        static::assertArrayHasKey('canonicalProduct', $response['elements'][0]);
+
+        $reviews = $response['elements'][0]['canonicalProduct']['productReviews'];
+        static::assertCount(1, $reviews);
+        static::assertSame('test public review', $reviews[0]['title']);
+    }
+
     public function testListingProductsIncludesOwnInactiveReviews(): void
     {
         $customerId = $this->login($this->browser);

--- a/tests/unit/Core/Content/Product/SalesChannel/SalesChannelProductDefinitionTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/SalesChannelProductDefinitionTest.php
@@ -3,9 +3,12 @@
 namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Generator;
 
@@ -44,5 +47,31 @@ class SalesChannelProductDefinitionTest extends TestCase
         static::assertEmpty($criteria->getAssociations());
 
         static::assertNotEmpty($criteria->getFilters());
+    }
+
+    #[DataProvider('reviewAssociationNestingLevelProvider')]
+    public function testProcessCriteriaHidesUnapprovedReviewsOnEveryNestingLevel(int $nestingLevel): void
+    {
+        $definition = new SalesChannelProductDefinition();
+        $criteria = new Criteria(nestingLevel: $nestingLevel);
+        $criteria->addAssociation('productReviews');
+        $context = Generator::generateSalesChannelContext();
+
+        $definition->processCriteria($criteria, $context);
+
+        static::assertEquals(
+            [new MultiFilter(MultiFilter::CONNECTION_OR, [
+                new EqualsFilter('status', true),
+                new EqualsFilter('customerId', Generator::CUSTOMER),
+            ])],
+            $criteria->getAssociation('productReviews')->getFilters()
+        );
+    }
+
+    public static function reviewAssociationNestingLevelProvider(): \Generator
+    {
+        yield 'reviews requested at the root of the criteria' => [Criteria::ROOT_NESTING_LEVEL];
+        yield 'reviews nested one level deeper, e.g. below the children association' => [1];
+        yield 'reviews nested arbitrarily deep' => [3];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

`SalesChannelProductDefinition::processCriteria` is the only place that keeps unapproved product reviews out of store-api responses, via a `status = true` filter on the `productReviews` association. Since 6.6.6.0 that filter is attached only when the criteria is at the root nesting level, because the early return added in `ac525af0097` sits above it.

`SalesChannelRepository::processCriteria` walks every association of the criteria, so the same association nested one level deeper reaches `processCriteria` and returns before the filter is added. An unauthenticated caller with only the public store-api access key can therefore read the title, content, rating and author display name of reviews that are still pending moderation, for any product reachable through a nested product association.

The early return was introduced to keep the default `prices`/`unit`/`deliveryTime`/`cover`/`tax` associations root-only. That commit already hoisted `ProductAvailableFilter` above the return to keep it applying at every level; the review filter was left below it.

### 2. What does this change do, exactly?

Moves the `productReviews` filter block above the `ROOT_NESTING_LEVEL` early return, so it is attached to every `productReviews` association regardless of nesting depth — the same treatment `ProductAvailableFilter` already gets. The `hasAssociation('productReviews')` guard keeps it a no-op when reviews are not requested.

Only the default association block stays root-only, which was the intent of the original change. Behaviour for logged-in customers is unchanged: they still see their own pending reviews through the `customerId` clause.

Added coverage:

- `SalesChannelProductDefinitionTest::testProcessCriteriaHidesUnapprovedReviewsOnEveryNestingLevel` — asserts the exact expected filter at nesting levels 0, 1 and 3.
- `ProductListRouteTest::testListingProductsIncludesOnlyPublicReviewsWhenNestedBelowChildren` — reviews nested under `children`.
- `ProductListRouteTest::testListingProductsIncludesOnlyPublicReviewsWhenNestedBelowAnyProductAssociation` — reviews nested under `canonicalProduct`, to pin that the fix is not specific to one association.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a product with a variant, both visible in a sales channel.
2. Add a review to the variant and leave it unapproved (`status = false`) — the default state for any customer-submitted review.
3. Request the parent product from the store-api with the reviews at the root of the criteria, using only the public `sw-access-key`:

   ```
   POST /store-api/product
   { "ids": ["<parent-id>"], "associations": { "productReviews": {} } }
   ```

   The pending review is correctly hidden.
4. Request the same association nested under the variant:

   ```
   POST /store-api/product
   { "ids": ["<parent-id>"], "associations": { "children": { "associations": { "productReviews": {} } } } }
   ```

   Before this change the pending review is returned under `elements[0].children[].productReviews`, including `title`, `content`, `points`, `status` and `externalUser`. After this change it is hidden, matching step 3.

### 4. Please link to the relevant issues (if any).

- Security advisory: https://github.com/shopware/shopware/security/advisories/GHSA-674c-5376-96rv

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers — not relevant here: this restores the intended, already-documented behaviour and changes no external contract
- [x] I have written or adjusted the documentation and agent skills according to my changes — no documentation or skill change needed
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
