### PR TITLE
fix: match promotion All/None-of when cart has no promotions

### DIFF
--- a/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
+++ b/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
@@ -51,7 +51,10 @@ class MatchAllLineItemsRule extends Container
         $filteredCount = \is_array($lineItems) ? \count($lineItems) : $lineItems->count();
 
         if ($filteredCount === 0) {
-            return false;
+            // "All promotions …" is vacuously true when no promotions are in the cart.
+            // Other type filters (e.g. product tags) must not match when no items remain.
+            return $this->type === LineItem::PROMOTION_LINE_ITEM_TYPE
+                && $this->minimumShouldMatch === null;
         }
 
         $context = $scope->getSalesChannelContext();

--- a/tests/unit/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\Cart\Rule\LineItemInCategoryRule;
 use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
+use Shopware\Core\Checkout\Promotion\Rule\PromotionLineItemRule;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Container\Container;
 use Shopware\Core\Framework\Rule\Container\MatchAllLineItemsRule;
@@ -264,6 +265,51 @@ class MatchAllLineItemsRuleTest extends TestCase
             'no type match / promotion / minimum set / returns false' => [LineItem::PROMOTION_LINE_ITEM_TYPE, 1, false],
             'no type match / custom / no minimum / returns false' => [LineItem::CUSTOM_LINE_ITEM_TYPE, null, false],
             'no type match / custom / minimum set / returns false' => [LineItem::CUSTOM_LINE_ITEM_TYPE, 1, false],
+        ];
+    }
+
+    #[DataProvider('getPromotionTypeFilterWithProductsTestData')]
+    public function testPromotionTypeFilterWithProductsInCart(
+        string $operator,
+        bool $includeSelectedPromotion,
+        bool $expected
+    ): void {
+        $promotionId = 'selected-promotion-id';
+
+        $promotionRule = new PromotionLineItemRule($operator, [$promotionId]);
+
+        $allLineItemsRule = new MatchAllLineItemsRule([], null, LineItem::PROMOTION_LINE_ITEM_TYPE);
+        $allLineItemsRule->addRule($promotionRule);
+
+        $lineItems = new LineItemCollection([
+            $this->createLineItem(LineItem::PRODUCT_LINE_ITEM_TYPE, 1, 'PRODUCT'),
+        ]);
+
+        if ($includeSelectedPromotion) {
+            $lineItems->add(
+                $this->createLineItem(LineItem::PROMOTION_LINE_ITEM_TYPE, 1, 'PROMO')
+                    ->setPayloadValue('promotionId', $promotionId)
+            );
+        }
+
+        $match = $allLineItemsRule->match(new CartRuleScope(
+            $this->createCart($lineItems),
+            $this->createMock(SalesChannelContext::class)
+        ));
+
+        static::assertSame($expected, $match);
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    public static function getPromotionTypeFilterWithProductsTestData(): array
+    {
+        return [
+            'products only / none of / matches vacuously' => [Rule::OPERATOR_NEQ, false, true],
+            'products only / are one of / matches vacuously' => [Rule::OPERATOR_EQ, false, true],
+            'products and selected promotion / none of / does not match' => [Rule::OPERATOR_NEQ, true, false],
+            'products and selected promotion / are one of / matches' => [Rule::OPERATOR_EQ, true, true],
         ];
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
https://github.com/shopware/shopware/pull/17211 made empty type filters always return false, so **Promotion -> All -> Are None of** no longer matched when the cart had products but no promotions (e.g. shipping availability rules).

### 2. What does this change do, exactly?
If the promotion type filter yields no items, treat the All-container as a vacuous match again. Product/custom empty filters stay false (keeps the `LineItemTagRule` fix from #17211).

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a rule: Promotion -> All -> Are None of -> pick any promotion.
2. Assign it as a shipping method availability rule.
3. Add a product to the cart, apply no promotion.
4. Shipping method is missing (rule does not match).

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/shopware/issues/18767

### 5. Checklist
- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
