### PR TITLE
fix(framework): validate sync delete criteria permissions (backport: 6.6.x)

### DIFF
--- a/src/Core/Framework/Api/Sync/SyncService.php
+++ b/src/Core/Framework/Api/Sync/SyncService.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Api\Sync;
 
 use Shopware\Core\Framework\Adapter\Database\ReplicaConnection;
+use Shopware\Core\Framework\Api\Acl\AclCriteriaValidator;
 use Shopware\Core\Framework\Api\ApiException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
@@ -32,6 +33,7 @@ class SyncService implements SyncServiceInterface
         private readonly DefinitionInstanceRegistry $registry,
         private readonly EntitySearcherInterface $searcher,
         private readonly RequestCriteriaBuilder $criteriaBuilder,
+        private readonly AclCriteriaValidator $criteriaValidator,
         private readonly SyncFkResolver $syncFkResolver
     ) {
     }
@@ -151,6 +153,11 @@ class SyncService implements SyncServiceInterface
 
         if (empty($criteria->getFilters())) {
             throw ApiException::invalidSyncCriteriaException($operation->getKey());
+        }
+
+        $missingPrivileges = $this->criteriaValidator->validate($definition->getEntityName(), $criteria, $context);
+        if ($missingPrivileges !== []) {
+            throw ApiException::missingPrivileges($missingPrivileges);
         }
 
         $ids = $this->searcher->search($definition, $criteria, $context);

--- a/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
+++ b/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
@@ -683,6 +683,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder"/>
+            <argument type="service" id="Shopware\Core\Framework\Api\Acl\AclCriteriaValidator"/>
             <argument type="service" id="Shopware\Core\Framework\Api\Sync\SyncFkResolver"/>
         </service>
 

--- a/tests/integration/Core/Framework/Api/Controller/SyncControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/SyncControllerTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Increment\AbstractIncrementer;
 use Shopware\Core\Framework\Increment\IncrementGatewayRegistry;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseHelper\TestUser;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
 use Symfony\Component\HttpFoundation\Response;
@@ -357,6 +358,56 @@ class SyncControllerTest extends TestCase
             ['id' => ArrayParameterType::BINARY]
         );
         static::assertEmpty($exists);
+    }
+
+    public function testCriteriaDeleteRequiresReadPrivilegesForCriteriaSelection(): void
+    {
+        $victimId = Uuid::randomHex();
+        $controlId = Uuid::randomHex();
+        $manufacturerName = Uuid::randomHex();
+
+        foreach ([$victimId => $manufacturerName, $controlId => Uuid::randomHex()] as $productId => $name) {
+            $this->getBrowser()->jsonRequest('POST', '/api/product', [
+                'id' => $productId,
+                'productNumber' => Uuid::randomHex(),
+                'stock' => 1,
+                'name' => Uuid::randomHex(),
+                'tax' => ['name' => Uuid::randomHex(), 'taxRate' => 15],
+                'manufacturer' => ['name' => $name],
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 50, 'net' => 25, 'linked' => false]],
+            ]);
+
+            static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), (string) $this->getBrowser()->getResponse()->getContent());
+        }
+
+        TestUser::createNewTestUser($this->connection, ['product:delete'])->authorizeBrowser($this->getBrowser());
+
+        $this->getBrowser()->jsonRequest('POST', '/api/_action/sync', [[
+            'action' => SyncController::ACTION_DELETE,
+            'entity' => ProductDefinition::ENTITY_NAME,
+            'criteria' => [[
+                'type' => 'equals',
+                'field' => 'manufacturer.name',
+                'value' => $manufacturerName,
+            ]],
+        ]]);
+
+        $response = $this->getBrowser()->getResponse();
+        $content = (string) $response->getContent();
+
+        static::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), $content);
+        static::assertSame(
+            ['product:read', 'product_manufacturer:read'],
+            json_decode(json_decode($content, true, flags: \JSON_THROW_ON_ERROR)['errors'][0]['detail'], true, flags: \JSON_THROW_ON_ERROR)['missingPrivileges']
+        );
+
+        $existingIds = $this->connection->fetchFirstColumn(
+            'SELECT LOWER(HEX(id)) FROM product WHERE id IN (:ids)',
+            ['ids' => [Uuid::fromHexToBytes($victimId), Uuid::fromHexToBytes($controlId)]],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+
+        static::assertEqualsCanonicalizing([$victimId, $controlId], $existingIds);
     }
 
     public function testIndexingByQueueHeader(): void

--- a/tests/unit/Core/Framework/Api/Sync/SyncServiceTest.php
+++ b/tests/unit/Core/Framework/Api/Sync/SyncServiceTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductCategory\ProductCategoryDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Api\Acl\AclCriteriaValidator;
+use Shopware\Core\Framework\Api\ApiException;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Sync\SyncBehavior;
 use Shopware\Core\Framework\Api\Sync\SyncFkResolver;
@@ -147,6 +148,46 @@ class SyncServiceTest extends TestCase
         );
 
         $service->sync($operations, Context::createCLIContext(), new SyncBehavior());
+    }
+
+    public function testCriteriaDeleteDoesNotSearchWithoutReadPrivileges(): void
+    {
+        $filter = [['type' => 'equals', 'field' => 'productNumber', 'value' => 'product-number']];
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('productNumber', 'product-number'));
+
+        $criteriaBuilder = $this->createMock(RequestCriteriaBuilder::class);
+        $criteriaBuilder->expects($this->once())
+            ->method('fromArray')
+            ->with(['filter' => $filter])
+            ->willReturn($criteria);
+
+        $criteriaValidator = $this->createMock(AclCriteriaValidator::class);
+        $criteriaValidator->expects($this->once())
+            ->method('validate')
+            ->willReturn(['product:read']);
+
+        $searcher = $this->createMock(EntitySearcherInterface::class);
+        $searcher->expects($this->never())->method('search');
+
+        $service = new SyncService(
+            static::createStub(EntityWriterInterface::class),
+            static::createStub(EventDispatcherInterface::class),
+            new StaticDefinitionInstanceRegistry(
+                [ProductDefinition::class],
+                static::createStub(ValidatorInterface::class),
+                static::createStub(EntityWriteGatewayInterface::class),
+            ),
+            $searcher,
+            $criteriaBuilder,
+            $criteriaValidator,
+            static::createStub(SyncFkResolver::class)
+        );
+
+        $this->expectExceptionObject(ApiException::missingPrivileges(['product:read']));
+
+        $service->sync([
+            new SyncOperation('delete-products', 'product', SyncOperation::ACTION_DELETE, [], $filter),
+        ], Context::createDefaultContext(), new SyncBehavior());
     }
 
     public function testWrittenEventsAreDispatchedInSystemScopeWithOriginalSource(): void

--- a/tests/unit/Core/Framework/Api/Sync/SyncServiceTest.php
+++ b/tests/unit/Core/Framework/Api/Sync/SyncServiceTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductCategory\ProductCategoryDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\Api\Acl\AclCriteriaValidator;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Sync\SyncBehavior;
 use Shopware\Core\Framework\Api\Sync\SyncFkResolver;
@@ -70,6 +71,7 @@ class SyncServiceTest extends TestCase
             ),
             $this->createMock(EntitySearcherInterface::class),
             $this->createMock(RequestCriteriaBuilder::class),
+            $this->createMock(AclCriteriaValidator::class),
             $this->createMock(SyncFkResolver::class)
         );
 
@@ -140,6 +142,7 @@ class SyncServiceTest extends TestCase
                 new CriteriaArrayConverter(new AggregationParser()),
                 100
             ),
+            $this->createMock(AclCriteriaValidator::class),
             $this->createMock(SyncFkResolver::class)
         );
 
@@ -194,6 +197,7 @@ class SyncServiceTest extends TestCase
             ),
             $this->createMock(EntitySearcherInterface::class),
             $this->createMock(RequestCriteriaBuilder::class),
+            $this->createMock(AclCriteriaValidator::class),
             $this->createMock(SyncFkResolver::class)
         );
 
@@ -274,6 +278,7 @@ class SyncServiceTest extends TestCase
             ),
             $searcher,
             $criteriaBuilder,
+            $this->createMock(AclCriteriaValidator::class),
             $this->createMock(SyncFkResolver::class)
         );
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Backports the Sync criteria-delete permission validation to 6.6.x.

### 2. What does this change do, exactly?

Requires read privileges for criteria before resolving records for Sync API delete operations.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use an Admin API user with delete permission but without the required read permissions.
2. Submit a criteria-delete Sync request.
3. The request is rejected before records are resolved.

### 4. Please link to the relevant issues (if any).

- Backport of #19009

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Not relevant; this restores intended permission enforcement without an external migration.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them