### PR TITLE
ci: authenticate the codeowners PR-head fetch explicitly

### DIFF
--- a/.github/actions/codeowners-plus-status/action.yaml
+++ b/.github/actions/codeowners-plus-status/action.yaml
@@ -11,12 +11,20 @@ inputs:
   head-sha:
     description: 'Commit the status is reported on'
     required: true
+  github-token:
+    description: 'Token to authenticate the PR-head fetch below with — the checkout step strips its own credential on purpose'
+    required: true
 
 runs:
   using: composite
   steps:
     - shell: bash
-      run: git fetch --no-tags origin "pull/${{ inputs.pr-number }}/head"
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+      run: |
+        git -c http.extraheader="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)" \
+          fetch --no-tags origin "pull/${PR_NUMBER}/head"
 
     # GITHUB_TOKEN has no organization scope, so requesting a review from a team
     # fails with "Could not resolve to a node with the global id of 'T_…'". No

--- a/.github/workflows/codeowner-fork-review-handler.yml
+++ b/.github/workflows/codeowner-fork-review-handler.yml
@@ -57,3 +57,4 @@ jobs:
           pr-number: ${{ steps.pr-number.outputs.number }}
           draft: ${{ steps.pr.outputs.draft }}
           head-sha: ${{ steps.pr.outputs.head-sha }}
+          github-token: ${{ github.token }}

--- a/.github/workflows/codeowner.yml
+++ b/.github/workflows/codeowner.yml
@@ -26,9 +26,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/codeowners-plus-status
         with:
           pr-number: ${{ github.event.pull_request.number }}
           draft: ${{ github.event.pull_request.draft }}
           head-sha: ${{ github.event.pull_request.head.sha }}
+          github-token: ${{ github.token }}


### PR DESCRIPTION
### 1. Why is this change necessary?

`persist-credentials: false` leaves the later PR-head fetch unauthenticated. Public repos tolerate that; private ones don't — every PR in the synced `shopware-private` copy 403'd at that step (shopware-private#302).

### 2. What does this change do, exactly?

Scopes a token to that one `git fetch` via `http.extraheader` instead of persisting a credential for the job. Verified against the real `shopware-private` repo: unauthenticated fetch reproduces the error, the extraheader fetch succeeds.

### 3. Describe each step to reproduce the issue or behaviour.

Open a PR against a private downstream repo that syncs this workflow: `Run Codeowners Plus` fails at `Fetch PR head`.

### 4. Please link to the relevant issues (if any).

Fixes shopware-private#302's CI failure. Follows up on #18980, #18998.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
