### PR TITLE
refactor(core): migrate service constructor deprecations

### DIFF
--- a/src/Core/Framework/Adapter/Cache/Http/CacheStore.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheStore.php
@@ -41,11 +41,12 @@ class CacheStore implements StoreInterface
      * @internal
      *
      * @param array<string, mixed> $sessionOptions
-     *
-     * @deprecated tag:v6.8.0 - Parameter $stateValidator will be removed
      */
     public function __construct(
         private readonly TagAwareAdapterInterface&CacheInterface $cache,
+        /**
+         * @deprecated tag:v6.8.0 - Parameter $stateValidator will be removed
+         */
         private readonly CacheStateValidator $stateValidator,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly HttpCacheKeyGenerator $cacheKeyGenerator,

--- a/src/Core/Framework/Adapter/Cache/ReverseProxy/ReverseProxyCache.php
+++ b/src/Core/Framework/Adapter/Cache/ReverseProxy/ReverseProxyCache.php
@@ -24,11 +24,12 @@ class ReverseProxyCache implements StoreInterface
      * @internal
      *
      * @param string[] $states
-     *
-     * @deprecated tag:v6.8.0 - Parameter $states will be removed
      */
     public function __construct(
         private readonly AbstractReverseProxyGateway $gateway,
+        /**
+         * @deprecated tag:v6.8.0 - Parameter $states will be removed
+         */
         private readonly array $states,
         private readonly CacheTagCollector $collector
     ) {

--- a/src/Core/Framework/Adapter/Twig/Extension/NodeExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/NodeExtension.php
@@ -18,10 +18,11 @@ class NodeExtension extends AbstractExtension
 {
     /**
      * @internal
-     *
-     * @deprecated tag:v6.8.0  - replace TemplateFinder with TemplateFinderInterface
      */
     public function __construct(
+        /**
+         * @deprecated tag:v6.8.0 - Replace TemplateFinder with TemplateFinderInterface
+         */
         private readonly TemplateFinder $finder,
         private readonly TemplateScopeDetector $templateScopeDetector,
     ) {

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
@@ -13,10 +13,11 @@ class Tokenizer implements TokenizerInterface
      * @param string[] $preservedChars
      *
      * @internal
-     *
-     *  @deprecated tag:v6.8.0 - Property `$tokenMinimumLength` will be removed
      */
     public function __construct(
+        /**
+         * @deprecated tag:v6.8.0 - Property `$tokenMinimumLength` will be removed
+         */
         private readonly int $tokenMinimumLength,
         private readonly array $preservedChars = ['-', '_', '+', '.', '@']
     ) {

--- a/src/Storefront/Controller/AccountOrderController.php
+++ b/src/Storefront/Controller/AccountOrderController.php
@@ -52,8 +52,6 @@ class AccountOrderController extends StorefrontController
 {
     /**
      * @internal
-     *
-     * @deprecated tag:v6.8.0 - Property `AccountOrderDetailPageLoader` will be removed
      */
     public function __construct(
         private readonly AccountOrderPageLoader $orderPageLoader,
@@ -63,6 +61,9 @@ class AccountOrderController extends StorefrontController
         private readonly AbstractSetPaymentOrderRoute $setPaymentOrderRoute,
         private readonly AbstractHandlePaymentMethodRoute $handlePaymentMethodRoute,
         private readonly EventDispatcherInterface $eventDispatcher,
+        /**
+         * @deprecated tag:v6.8.0 - Property `AccountOrderDetailPageLoader` will be removed
+         */
         private readonly AccountOrderDetailPageLoader $orderDetailPageLoader,
         private readonly AbstractOrderRoute $orderRoute,
         private readonly SalesChannelContextServiceInterface $contextService,


### PR DESCRIPTION
### 1. Why is this change necessary?

The deprecated dependencies of internal DI services are represented on their constructors, although the individual constructor parameters—not construction by the container—will change in 6.8.

### 2. What does this change do, exactly?

Moves the deprecation metadata to the affected promoted constructor parameters of the internal services.

### 3. Describe each step to reproduce the issue or behaviour.

1. Inspect the affected service constructors.
2. The deprecated annotation is now attached to the parameter that will be removed.

### 4. Please link to the relevant issues (if any).

Required before [#19043](https://github.com/shopware/shopware/pull/19043) can be merged, as it enables the enforcing PHPStan rules.

### 5. Checklist

- [x] I have written tests and verified the changed behavior
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
