### PR TITLE
ci: run Lighthouse only in public repository

### DIFF
--- a/.github/workflows/admin-performance.yml
+++ b/.github/workflows/admin-performance.yml
@@ -24,7 +24,7 @@ jobs:
     name: "Lighthouse CI"
     needs:
       - markdown-only-changes
-    if: ${{ needs.markdown-only-changes.outputs.docs_only != 'true' }}
+    if: ${{ github.repository == 'shopware/shopware' && needs.markdown-only-changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-24.04
     env:
       APP_ENV: prod
@@ -115,5 +115,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
-          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'lighthouse' || '' }}
+          allowed-skips: ${{ (github.repository != 'shopware/shopware' || needs.markdown-only-changes.outputs.docs_only == 'true') && 'lighthouse' || '' }}
           jobs: ${{ toJSON(needs) }}

--- a/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
+++ b/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
@@ -3,11 +3,6 @@ import { test } from '@fixtures/AcceptanceTest';
 /**
  * These tests should only run against APP_ENV=Prod
  */
-test.skip(
-    process.env.GITHUB_REPOSITORY !== undefined && process.env.GITHUB_REPOSITORY !== 'shopware/shopware',
-    'Lighthouse tests run only in shopware/shopware.',
-);
-
 test('Product Detail Lighthouse Report', async ({
     ShopCustomer,
     TestDataService,

--- a/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
+++ b/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
@@ -3,6 +3,11 @@ import { test } from '@fixtures/AcceptanceTest';
 /**
  * These tests should only run against APP_ENV=Prod
  */
+test.skip(
+    process.env.GITHUB_REPOSITORY !== undefined && process.env.GITHUB_REPOSITORY !== 'shopware/shopware',
+    'Lighthouse tests run only in shopware/shopware.',
+);
+
 test('Product Detail Lighthouse Report', async ({
     ShopCustomer,
     TestDataService,


### PR DESCRIPTION
### 1. Why is this change necessary?

Private repositories use lower-capacity standard GitHub-hosted runners than the public repository. The Lighthouse total-blocking-time threshold therefore fails without an Administration performance regression.

### 2. What does this change do, exactly?

Runs Lighthouse only in `shopware/shopware` and permits the expected Lighthouse skip in private mirrors.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a pull request in `shopware/shopware-private`.
2. Observe that the Lighthouse job runs on the private repository's standard runner and can exceed the total-blocking-time threshold.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
