### PR TITLE
fix(framework): signal actionable runtime deprecations

### DIFF
--- a/src/Administration/Framework/Adapter/Cache/Http/AdministrationCacheControlListener.php
+++ b/src/Administration/Framework/Adapter/Cache/Http/AdministrationCacheControlListener.php
@@ -11,7 +11,7 @@ use Shopware\Core\PlatformRequest;
 /**
  * @internal
  *
- * @deprecated tag:v6.8.0 - Will be removed together with the BeforeCacheControlEvent and the CacheControlListener it hooks into.
+ * @deprecated tag:v6.8.0 - reason:remove-subscriber - Will be removed together with the BeforeCacheControlEvent and the CacheControlListener it hooks into.
  */
 #[Package('framework')]
 readonly class AdministrationCacheControlListener

--- a/src/Core/Checkout/DocumentV2/Config/DocumentConfigBundle.php
+++ b/src/Core/Checkout/DocumentV2/Config/DocumentConfigBundle.php
@@ -14,13 +14,14 @@ final readonly class DocumentConfigBundle
 {
     /**
      * @param array<string, mixed> $legacyConfig
-     *
-     * @deprecated tag:v6.8.0 - $legacyConfig will be removed once all fields are migrated to typed properties
      */
     public function __construct(
         public DocumentConfig $config,
         public DocumentCompanyInfo $company,
         public DocumentDisplayOptions $display,
+        /**
+         * @deprecated tag:v6.8.0 - $legacyConfig will be removed once all fields are migrated to typed properties
+         */
         public array $legacyConfig,
     ) {
     }

--- a/src/Core/Framework/Adapter/Cache/Http/CacheControlListener.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheControlListener.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  *
- * @deprecated tag:v6.8.0 - Will be removed without replacement
+ * @deprecated tag:v6.8.0 - reason:remove-subscriber - Will be removed without replacement
  */
 #[Package('framework')]
 readonly class CacheControlListener

--- a/src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
@@ -66,6 +66,16 @@ abstract class EntityDefinition
      */
     public function __construct()
     {
+        $caller = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1] ?? [];
+
+        if (($caller['function'] ?? null) !== '__construct') {
+            return;
+        }
+
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0')
+        );
     }
 
     /**

--- a/src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
@@ -66,9 +66,12 @@ abstract class EntityDefinition
      */
     public function __construct()
     {
+        // When a child calls parent::__construct(), the next stack frame is that child's constructor.
+        // An inherited constructor has its instantiation site as the caller instead, so it remains compatible with the removal.
         $caller = \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1] ?? [];
+        $callerClass = $caller['class'] ?? null;
 
-        if (($caller['function'] ?? null) !== '__construct') {
+        if (($caller['function'] ?? null) !== '__construct' || !\is_string($callerClass) || !\is_subclass_of($callerClass, self::class)) {
             return;
         }
 

--- a/src/Core/Framework/Webhook/Command/WebhookDrainToAsyncCommand.php
+++ b/src/Core/Framework/Webhook/Command/WebhookDrainToAsyncCommand.php
@@ -69,6 +69,11 @@ final readonly class WebhookDrainToAsyncCommand
         #[Option(description: 'Skip the interactive confirmation prompt', shortcut: 'f')]
         bool $force = false,
     ): int {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            'The webhook:drain-to-async command is deprecated and will be removed in v6.8.0.0.',
+        );
+
         if (Feature::isActive('WEBHOOKS_REWORK')) {
             $io->error('WEBHOOKS_REWORK is active. This drain is only for after the flag is off — running it now would race the rework consumer.');
 

--- a/tests/integration/Core/Framework/Webhook/Command/WebhookDrainToAsyncCommandTest.php
+++ b/tests/integration/Core/Framework/Webhook/Command/WebhookDrainToAsyncCommandTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\App\AppLocaleProvider;
 use Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Feature\FeatureException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -46,6 +47,8 @@ class WebhookDrainToAsyncCommandTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $this->connection = static::getContainer()->get(Connection::class);
         $this->messageBus = static::getContainer()->get('messenger.default_bus');
 
@@ -156,6 +159,15 @@ class WebhookDrainToAsyncCommandTest extends TestCase
         // Row must remain QUEUED — the drain refused before touching anything.
         $row = $this->fetchDeliveryRow('wh-1');
         static::assertSame(WebhookEventLogDefinition::STATUS_QUEUED, $row['delivery_status']);
+    }
+
+    public function testRollbackDrainThrowsDeprecationWhenMajorFeatureIsActive(): void
+    {
+        $this->expectException(FeatureException::class);
+
+        Feature::withFeatureEnabled('v6.8.0.0', function (): void {
+            $this->runCommand(['--force' => true]);
+        });
     }
 
     public function testRollbackDrainAbortsWhenConfirmationDeclined(): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/EntityDefinitionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/EntityDefinitionTest.php
@@ -22,13 +22,42 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
 #[CoversClass(EntityDefinition::class)]
 class EntityDefinitionTest extends TestCase
 {
+    public function testInheritedConstructorDoesNotSignalDeprecationWhenInstantiatedFromAnotherConstructor(): void
+    {
+        $caller = new class {
+            public EntityDefinition $definition;
+
+            public function __construct()
+            {
+                $this->definition = new class extends EntityDefinition {
+                    public const ENTITY_NAME = 'test_definition';
+
+                    public function getEntityName(): string
+                    {
+                        return self::ENTITY_NAME;
+                    }
+
+                    protected function defineFields(): FieldCollection
+                    {
+                        return new FieldCollection();
+                    }
+                };
+            }
+        };
+
+        static::assertSame('test_definition', $caller->definition->getEntityName());
+    }
+
     public function testConstructorSignalsDeprecationWhenCalledByChildConstructor(): void
     {
         $this->expectExceptionObject(FeatureException::error(
             'Tried to access deprecated functionality: ' . Feature::deprecatedMethodMessage(EntityDefinition::class, '__construct', 'v6.8.0.0')
         ));
 
+        /** @phpstan-ignore-next-line - Intentionally testing the deprecated parent constructor. */
         new class extends EntityDefinition {
+            public const ENTITY_NAME = 'test_definition';
+
             public function __construct()
             {
                 parent::__construct();
@@ -36,7 +65,7 @@ class EntityDefinitionTest extends TestCase
 
             public function getEntityName(): string
             {
-                return 'test-definition';
+                return self::ENTITY_NAME;
             }
 
             protected function defineFields(): FieldCollection

--- a/tests/unit/Core/Framework/DataAbstractionLayer/EntityDefinitionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/EntityDefinitionTest.php
@@ -10,6 +10,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Feature\FeatureException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 
@@ -20,6 +22,30 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
 #[CoversClass(EntityDefinition::class)]
 class EntityDefinitionTest extends TestCase
 {
+    public function testConstructorSignalsDeprecationWhenCalledByChildConstructor(): void
+    {
+        $this->expectExceptionObject(FeatureException::error(
+            'Tried to access deprecated functionality: ' . Feature::deprecatedMethodMessage(EntityDefinition::class, '__construct', 'v6.8.0.0')
+        ));
+
+        new class extends EntityDefinition {
+            public function __construct()
+            {
+                parent::__construct();
+            }
+
+            public function getEntityName(): string
+            {
+                return 'test-definition';
+            }
+
+            protected function defineFields(): FieldCollection
+            {
+                return new FieldCollection();
+            }
+        };
+    }
+
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetFieldsLegacyBehaviour(): void
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

Executable deprecations must provide an actionable runtime signal, while internal implementation cleanup must not create deprecation noise for Shopware itself.

### 2. What does this change do, exactly?

Adds runtime handling for the deprecated webhook handler and explicit `EntityDefinition` parent-constructor calls, keeps deprecated subscriber behavior intentional, and moves the internal document-config marker to its affected parameter.

### 3. Describe each step to reproduce the issue or behaviour.

1. Invoke the deprecated webhook handler or explicitly call `parent::__construct()` from an entity definition.
2. The v6.8 deprecation is signaled.
3. Construct an entity definition through its inherited constructor: no deprecation is emitted.

### 4. Please link to the relevant issues (if any).

Required before [#19043](https://github.com/shopware/shopware/pull/19043) can be merged, as it enables the enforcing PHPStan rules.

### 5. Checklist

- [x] I have written tests and verified the changed behavior
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
