### PR TITLE
chore: Prepare rate limiter for PHPStan update 2026-08

### DIFF
--- a/src/Core/Framework/RateLimiter/Policy/SystemConfigLimiter.php
+++ b/src/Core/Framework/RateLimiter/Policy/SystemConfigLimiter.php
@@ -10,11 +10,14 @@ use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\NoLock;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 
+/**
+ * @phpstan-type SystemConfigLimit array{domain: string, interval: string}
+ */
 #[Package('framework')]
 class SystemConfigLimiter extends TimeBackoffLimiter
 {
     /**
-     * @param list<array{domain?: string, limit?: int, interval: string}> $limits
+     * @param list<SystemConfigLimit> $limits
      */
     public function __construct(
         SystemConfigService $systemConfigService,
@@ -25,17 +28,17 @@ class SystemConfigLimiter extends TimeBackoffLimiter
         ?LockInterface $lock = null,
         ?ClockInterface $clock = null,
     ) {
-        foreach ($limits as $idx => $limit) {
-            if (!isset($limit['domain'])) {
-                continue;
-            }
+        $convertedLimits = [];
+        foreach ($limits as $limit) {
+            $sysLimit = $systemConfigService->getInt($limit['domain'] ?? '');
+            $convertedLimit = [
+                'interval' => $limit['interval'],
+                'limit' => $sysLimit !== 0 ? $sysLimit : \PHP_INT_MAX,
+            ];
 
-            $sysLimit = $systemConfigService->get($limit['domain']);
-            $limits[$idx]['limit'] = $sysLimit && (int) $sysLimit !== 0 ? (int) $sysLimit : \PHP_INT_MAX;
-            unset($limits[$idx]['domain']);
+            $convertedLimits[] = $convertedLimit;
         }
 
-        /** @var list<array{limit: int, interval: string}> $limits */
-        parent::__construct($id, $limits, $reset, $storage, $clock ?? new NativeClock(), $lock ?? new NoLock());
+        parent::__construct($id, $convertedLimits, $reset, $storage, $clock ?? new NativeClock(), $lock ?? new NoLock());
     }
 }

--- a/src/Core/Framework/RateLimiter/RateLimiterFactory.php
+++ b/src/Core/Framework/RateLimiter/RateLimiterFactory.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\RateLimiter;
 use Psr\Clock\ClockInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\Policy\SystemConfigLimiter;
+use Shopware\Core\Framework\RateLimiter\Policy\TimeBackoff;
 use Shopware\Core\Framework\RateLimiter\Policy\TimeBackoffLimiter;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Lock\LockFactory;
@@ -15,15 +16,20 @@ use Symfony\Component\RateLimiter\RateLimiterFactory as SymfonyRateLimiterFactor
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 
 /**
- * @phpstan-type TimeBackoffLimit array{limit: int, interval: string}
+ * @phpstan-import-type TimeBackoffLimit from TimeBackoff
+ * @phpstan-import-type SystemConfigLimit from SystemConfigLimiter
+ *
  * @phpstan-type RateLimiterConfig array{
- *  enabled: bool,
- *  id: string,
- *  reset?: \DateInterval|string,
- *  policy: string,
- *  limits?: list<array{limit?: int, domain?: string, interval: string}>,
- *  limit?: int,
- *  rate?: array<string, string>
+ *     id: string,
+ *     enabled: bool,
+ *     lock_factory?: string,
+ *     policy: string,
+ *     limit?: int,
+ *     cache_pool?: string,
+ *     interval?: scalar,
+ *     reset?: \DateInterval|string,
+ *     rate?: array{interval: scalar, amount?: int},
+ *     limits?: list<TimeBackoffLimit|SystemConfigLimit>,
  * }
  */
 #[Package('framework')]
@@ -56,7 +62,7 @@ class RateLimiterFactory
             $this->config['reset'] = $this->clock->now()->diff($this->clock->now()->modify('+' . $this->config['reset']));
         }
 
-        if ($this->config['policy'] === 'time_backoff' && isset($this->config['limits']) && isset($this->config['reset'])) {
+        if ($this->config['policy'] === 'time_backoff' && isset($this->config['limits'], $this->config['reset'])) {
             /** @var list<TimeBackoffLimit> $limits */
             $limits = $this->config['limits'];
 
@@ -65,14 +71,16 @@ class RateLimiterFactory
             return new TimeBackoffLimiter($id, $limits, $this->config['reset'], $this->storage, $this->clock, $lock);
         }
 
-        if ($this->config['policy'] === 'system_config' && isset($this->config['limits']) && isset($this->config['reset'])) {
+        if ($this->config['policy'] === 'system_config' && isset($this->config['limits'], $this->config['reset'])) {
+            /** @var list<SystemConfigLimit> $limits */
+            $limits = $this->config['limits'];
+
             \assert($this->config['reset'] instanceof \DateInterval);
 
-            return new SystemConfigLimiter($this->systemConfigService, $id, $this->config['limits'], $this->config['reset'], $this->storage, $lock, $this->clock);
+            return new SystemConfigLimiter($this->systemConfigService, $id, $limits, $this->config['reset'], $this->storage, $lock, $this->clock);
         }
 
-        // prevent symfony errors due to customized values
-        /** @var RateLimiterConfig $rateLimiterConfig */
+        // prevent Symfony errors due to customized values
         $rateLimiterConfig = \array_filter($this->config, static fn ($key): bool => !\in_array($key, ['enabled', 'reset', 'cache_pool', 'lock_factory', 'limits'], true), \ARRAY_FILTER_USE_KEY);
 
         $sfFactory = new SymfonyRateLimiterFactory($rateLimiterConfig, $this->storage, $this->lockFactory);

--- a/tests/unit/Core/Framework/RateLimiter/Policy/RateLimiterFactoryTest.php
+++ b/tests/unit/Core/Framework/RateLimiter/Policy/RateLimiterFactoryTest.php
@@ -5,17 +5,22 @@ namespace Shopware\Tests\Unit\Core\Framework\RateLimiter\Policy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\RateLimiter\Policy\SystemConfigLimiter;
 use Shopware\Core\Framework\RateLimiter\Policy\TimeBackoffLimiter;
 use Shopware\Core\Framework\RateLimiter\RateLimiterFactory;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\RateLimiter\Policy\NoLimiter;
 use Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter;
 use Symfony\Component\RateLimiter\Policy\TokenBucketLimiter;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 
 /**
  * @internal
+ *
+ * @phpstan-import-type RateLimiterConfig from RateLimiterFactory
  */
 #[Package('framework')]
 #[CoversClass(RateLimiterFactory::class)]
@@ -47,6 +52,56 @@ class RateLimiterFactoryTest extends TestCase
         );
 
         static::assertInstanceOf(TimeBackoffLimiter::class, $factory->create('example'));
+    }
+
+    public function testFactoryShouldReturnNoLimiter(): void
+    {
+        $factory = new RateLimiterFactory(
+            [
+                'enabled' => false,
+                'id' => 'test_limiter',
+                'policy' => 'time_backoff',
+            ],
+            static::createStub(StorageInterface::class),
+            static::createStub(SystemConfigService::class),
+            new MockClock(),
+        );
+        static::assertInstanceOf(NoLimiter::class, $factory->create('example'));
+    }
+
+    public function testFactoryShouldReturnSystemConfigPolicy(): void
+    {
+        $systemConfigService = $this->createMock(SystemConfigService::class);
+        $systemConfigService->expects($this->once())
+            ->method('getInt')
+            ->with('core.cart.lineItemAddLimit')
+            ->willReturn(2);
+
+        $factory = new RateLimiterFactory(
+            [
+                'enabled' => true,
+                'id' => 'test_limiter',
+                'policy' => 'system_config',
+                'reset' => '1 hour',
+                'limits' => [
+                    [
+                        'domain' => 'core.cart.lineItemAddLimit',
+                        'interval' => '60 seconds',
+                    ],
+                ],
+            ],
+            new InMemoryStorage(),
+            $systemConfigService,
+            new MockClock(),
+            static::createStub(LockFactory::class),
+        );
+
+        $limiter = $factory->create('example');
+
+        static::assertInstanceOf(SystemConfigLimiter::class, $limiter);
+        static::assertTrue($limiter->consume()->isAccepted());
+        static::assertTrue($limiter->consume()->isAccepted());
+        static::assertFalse($limiter->consume()->isAccepted());
     }
 
     public function testFactoryShouldUseSymfonyFactory(): void

--- a/tests/unit/Core/Framework/RateLimiter/Policy/SystemConfigLimiterTest.php
+++ b/tests/unit/Core/Framework/RateLimiter/Policy/SystemConfigLimiterTest.php
@@ -82,7 +82,7 @@ class SystemConfigLimiterTest extends TestCase
     }
 
     /**
-     * @param array<string, int|null> $domainLimits
+     * @param array<string, int> $domainLimits
      */
     private function createLimiter(array $domainLimits): LimiterInterface
     {
@@ -91,7 +91,7 @@ class SystemConfigLimiterTest extends TestCase
 
         $systemConfig = $this->createMock(SystemConfigService::class);
         $systemConfig
-            ->expects($this->exactly(\array_key_exists('limit', $this->config['limits'][0]) ? 0 : 1))
+            ->expects($this->once())
             ->method('getInt')
             ->willReturnCallback(
                 static fn (string $domain) => $domainLimits[$domain] ?? 0

--- a/tests/unit/Core/Framework/RateLimiter/Policy/SystemConfigLimiterTest.php
+++ b/tests/unit/Core/Framework/RateLimiter/Policy/SystemConfigLimiterTest.php
@@ -51,9 +51,7 @@ class SystemConfigLimiterTest extends TestCase
 
     public function testConsume(): void
     {
-        $limiter = $this->createLimiter([
-            'test.limit' => 3,
-        ]);
+        $limiter = $this->createLimiter(['test.limit' => 3]);
 
         $limit = $limiter->consume();
         static::assertTrue($limit->isAccepted());
@@ -69,9 +67,7 @@ class SystemConfigLimiterTest extends TestCase
 
     public function testConsumeSequentiallyAllowsTheConfiguredLimit(): void
     {
-        $limiter = $this->createLimiter([
-            'test.limit' => 3,
-        ]);
+        $limiter = $this->createLimiter(['test.limit' => 3]);
 
         static::assertTrue($limiter->consume()->isAccepted());
         static::assertTrue($limiter->consume()->isAccepted());
@@ -81,40 +77,7 @@ class SystemConfigLimiterTest extends TestCase
 
     public function testNoLimitWithZero(): void
     {
-        $limiter = $this->createLimiter([
-            'test.limit' => 0,
-        ]);
-
-        $limit = $limiter->consume(100);
-        static::assertTrue($limit->isAccepted());
-    }
-
-    public function testLimitWithNoDomain(): void
-    {
-        static::assertArrayHasKey('limits', $this->config);
-        static::assertIsArray($this->config['limits']);
-
-        unset($this->config['limits'][0]['domain']);
-        $this->config['limits'][0]['limit'] = 10;
-
-        $limiter = $this->createLimiter([
-            'test.limit' => 0,
-        ]);
-
-        $limit = $limiter->consume(10);
-        static::assertTrue($limit->isAccepted());
-
-        $limit = $limiter->consume();
-        static::assertFalse($limit->isAccepted());
-    }
-
-    public function testNoLimitWithNull(): void
-    {
-        $limiter = $this->createLimiter([
-            'test.limit' => null,
-        ]);
-
-        $limit = $limiter->consume(100);
+        $limit = $this->createLimiter(['test.limit' => 0])->consume(100);
         static::assertTrue($limit->isAccepted());
     }
 
@@ -129,9 +92,9 @@ class SystemConfigLimiterTest extends TestCase
         $systemConfig = $this->createMock(SystemConfigService::class);
         $systemConfig
             ->expects($this->exactly(\array_key_exists('limit', $this->config['limits'][0]) ? 0 : 1))
-            ->method('get')
+            ->method('getInt')
             ->willReturnCallback(
-                static fn (string $domain) => $domainLimits[$domain] ?? null
+                static fn (string $domain) => $domainLimits[$domain] ?? 0
             );
 
         $cacheStorage = $this->createMock(CacheStorage::class);


### PR DESCRIPTION
### 1. Why is this change necessary?

Preparation for https://github.com/shopware/shopware/pull/17661

### 2. What does this change do, exactly?

Prepare rate limiter code for PHPStan update

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
