### PR TITLE
fix(storefront): keep whole image reachable in magnifier zoom

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
@@ -163,22 +163,29 @@ export default class MagnifierPlugin extends Plugin {
             this._createZoomImage();
             this._getImageUrl(image);
 
-            if (this._imageUrl && this._zoomImage && this._overlay) {
+            const geometry = this._getZoomGeometry(image);
+
+            if (this._imageUrl && this._zoomImage && this._overlay && geometry) {
                 const containerPos = this._getContainerPos(imageContainer);
                 const imagePos = this._getImagePos(image);
-                const imageDimensions = this._getImageDimensions(image);
-                const imageSize = this._getImageSize(image);
-                const overlaySize = this._getOverlaySize(imageSize);
                 const imageOffset = containerPos.subtract(imagePos);
                 imageOffset.x = Math.abs(imageOffset.x);
                 imageOffset.y = Math.abs(imageOffset.y);
 
-                const mousePos = new Vector2(event.pageX, event.pageY).subtract(imagePos);
+                this._setZoomImageSize(geometry.region.size);
 
-                const mousePosPercent = mousePos.divide(imageSize).clamp(0, 1);
+                const zoomWindowSize = this._getZoomImageSize();
+                const zoomFactor = this._getEffectiveZoomFactor(geometry.region.size, zoomWindowSize);
+                const overlaySize = this._getOverlaySize(geometry.region.size, zoomWindowSize, zoomFactor);
 
-                this._setOverlayPosition(imageOffset, overlaySize, imageSize, mousePosPercent);
-                this._setZoomImage(mousePos, imageSize, overlaySize, imageDimensions);
+                // mouse position relative to the visible image content, not to the image element
+                const mousePos = new Vector2(event.pageX, event.pageY)
+                    .subtract(imagePos)
+                    .subtract(geometry.region.offset);
+                const progress = this._getZoomProgress(mousePos, geometry.region.size, overlaySize);
+
+                this._setOverlayPosition(imageOffset.add(geometry.region.offset), overlaySize, geometry.region.size, progress);
+                this._setZoomImage(geometry, zoomWindowSize, zoomFactor, progress);
             }
         }
 
@@ -186,19 +193,128 @@ export default class MagnifierPlugin extends Plugin {
     }
 
     /**
-     * sets the position of the overlay
+     * returns the geometry needed to map the lens onto the zoomed image
      *
-     * @param {Vector2} imageOffset
-     * @param {Vector2} overlaySize
-     * @param {Vector2} imageSize
-     * @param {Vector2} mousePosPercent
-     * @return {VectorBase|*}
+     * `region` describes the area of the image element which actually renders image content,
+     * `source` describes the part of the image which is rendered inside that area.
+     * Both differ from the element itself as soon as `object-fit` letterboxes or crops the image.
+     * A centered `object-position` (the CSS default and the storefront default) is assumed.
+     *
+     * @param {HTMLElement} image
+     * @return {{natural: Vector2, scale: Vector2, region: {offset: Vector2, size: Vector2}, source: {offset: Vector2, size: Vector2}}|null}
+     *
      * @private
      */
-    _setOverlayPosition(imageOffset, overlaySize, imageSize, mousePosPercent) {
-        let overlayPos = imageOffset.subtract(overlaySize.divide(2)); // offset the lens so that the cursor is in the middle
-        overlayPos = overlayPos.add(imageSize.multiply(mousePosPercent)); // add the mouse offset
-        overlayPos = overlayPos.clamp(imageOffset, imageOffset.add(imageSize).subtract(overlaySize)); // clamp the position to image min max
+    _getZoomGeometry(image) {
+        const elementSize = this._getImageSize(image);
+        const natural = this._getImageDimensions(image);
+
+        if (elementSize.x <= 0 || elementSize.y <= 0 || natural.x <= 0 || natural.y <= 0) {
+            return null;
+        }
+
+        const scale = this._getObjectFitScale(image, elementSize, natural);
+        const renderedSize = natural.multiply(scale);
+
+        // the image content is either letterboxed inside the element or cropped by it
+        const regionSize = new Vector2(Math.min(renderedSize.x, elementSize.x), Math.min(renderedSize.y, elementSize.y));
+        const regionOffset = elementSize.subtract(regionSize).divide(2);
+        const sourceSize = regionSize.divide(scale);
+        const sourceOffset = natural.subtract(sourceSize).divide(2);
+
+        return {
+            natural,
+            scale,
+            region: { offset: regionOffset, size: regionSize },
+            source: { offset: sourceOffset, size: sourceSize },
+        };
+    }
+
+    /**
+     * returns the scale factor the browser applies to the image because of `object-fit`
+     *
+     * @param {HTMLElement} image
+     * @param {Vector2} elementSize
+     * @param {Vector2} natural
+     * @return {Vector2}
+     *
+     * @private
+     */
+    _getObjectFitScale(image, elementSize, natural) {
+        const fitScale = elementSize.divide(natural);
+        const objectFit = window.getComputedStyle(image).objectFit;
+
+        switch (objectFit) {
+            case 'fill':
+                return fitScale;
+            case 'cover':
+                return new Vector2(Math.max(fitScale.x, fitScale.y), Math.max(fitScale.x, fitScale.y));
+            case 'none':
+                return new Vector2(1, 1);
+            case 'scale-down':
+                return new Vector2(Math.min(fitScale.x, fitScale.y, 1), Math.min(fitScale.x, fitScale.y, 1));
+            case 'contain':
+            default:
+                // `contain` is the object-fit of the storefront gallery images and the safe fallback
+                // for unknown values (e.g. an empty string returned by jsdom in the unit tests)
+                return new Vector2(Math.min(fitScale.x, fitScale.y), Math.min(fitScale.x, fitScale.y));
+        }
+    }
+
+    /**
+     * returns the zoom factor which is actually applied
+     *
+     * The configured zoom factor is only usable as long as the zoomed image still covers the zoom window.
+     * Otherwise the zoom window would render empty areas next to the image.
+     *
+     * @param {Vector2} regionSize
+     * @param {Vector2} zoomWindowSize
+     * @return {number}
+     *
+     * @private
+     */
+    _getEffectiveZoomFactor(regionSize, zoomWindowSize) {
+        return Math.max(
+            this.options.zoomFactor,
+            zoomWindowSize.x / regionSize.x,
+            zoomWindowSize.y / regionSize.y,
+        );
+    }
+
+    /**
+     * returns how far the lens is moved inside its range, per axis, in a range of 0 to 1
+     *
+     * @param {Vector2} mousePos
+     * @param {Vector2} regionSize
+     * @param {Vector2} overlaySize
+     * @return {Vector2}
+     *
+     * @private
+     */
+    _getZoomProgress(mousePos, regionSize, overlaySize) {
+        const range = regionSize.subtract(overlaySize);
+        // offset the lens so that the cursor is in the middle
+        const lensPos = mousePos.subtract(overlaySize.divide(2));
+
+        return new Vector2(
+            range.x > 0 ? lensPos.x / range.x : 0,
+            range.y > 0 ? lensPos.y / range.y : 0,
+        ).clamp(0, 1);
+    }
+
+    /**
+     * sets the position of the overlay
+     *
+     * @param {Vector2} regionOffset
+     * @param {Vector2} overlaySize
+     * @param {Vector2} regionSize
+     * @param {Vector2} progress
+     * @return {Vector2}
+     * @private
+     */
+    _setOverlayPosition(regionOffset, overlaySize, regionSize, progress) {
+        const overlayPos = regionOffset.add(regionSize.subtract(overlaySize).multiply(progress));
+
         this._overlay.style.left = `${overlayPos.x}px`;
         this._overlay.style.top = `${overlayPos.y}px`;
 
@@ -206,30 +322,64 @@ export default class MagnifierPlugin extends Plugin {
     }
 
     /**
-     *  sets the background position of the zoomed image
+     *  sets the background size and position of the zoomed image
      *
-     * @param {Vector2} mousePos
-     * @param {Vector2} imageSize
-     * @param {Vector2} overlaySize
-     * @param {Vector2} imageDimensions
+     * @param {Object} geometry
+     * @param {Vector2} zoomWindowSize
+     * @param {number} zoomFactor
+     * @param {Vector2} progress
      *
      * @private
      */
-    _setZoomImage(mousePos, imageSize, overlaySize, imageDimensions) {
-        this._setZoomImageSize(imageSize);
-
+    _setZoomImage(geometry, zoomWindowSize, zoomFactor, progress) {
         // set background image
         this._zoomImage.style.backgroundImage = `url('${this._imageUrl}')`;
 
         // set background image size
-        const zoomImageBackgroundSize = this.calculateZoomBackgroundImageSize(imageDimensions, imageSize);
-        this._zoomImage.style.backgroundSize = `${zoomImageBackgroundSize.x}px ${zoomImageBackgroundSize.y}px`;
+        const backgroundSize = this._getZoomBackgroundSize(geometry, zoomFactor);
+        this._zoomImage.style.backgroundSize = `${backgroundSize.x}px ${backgroundSize.y}px`;
 
         // set background image position
-        const zoomImagePosPercent = this.calculateZoomImageBackgroundPosition(mousePos, imageSize, overlaySize, imageDimensions, zoomImageBackgroundSize);
-        this._zoomImage.style.backgroundPosition = `-${zoomImagePosPercent.x}px -${zoomImagePosPercent.y}px`;
+        const backgroundOffset = this._getZoomBackgroundOffset(geometry, zoomWindowSize, zoomFactor, progress);
+        this._zoomImage.style.backgroundPosition = `${-backgroundOffset.x}px ${-backgroundOffset.y}px`;
 
         this.$emitter.publish('setZoomImagePosition');
+    }
+
+    /**
+     * returns the size the whole image is rendered with inside the zoom window
+     *
+     * @param {Object} geometry
+     * @param {number} zoomFactor
+     * @return {Vector2}
+     *
+     * @private
+     */
+    _getZoomBackgroundSize(geometry, zoomFactor) {
+        return geometry.natural.multiply(geometry.scale).multiply(zoomFactor);
+    }
+
+    /**
+     * returns the offset of the zoomed image inside the zoom window
+     *
+     * The pannable range is the difference between the zoomed image content and the zoom window,
+     * which keeps every part of the image reachable for any zoom window size and aspect ratio.
+     *
+     * @param {Object} geometry
+     * @param {Vector2} zoomWindowSize
+     * @param {number} zoomFactor
+     * @param {Vector2} progress
+     * @return {Vector2}
+     *
+     * @private
+     */
+    _getZoomBackgroundOffset(geometry, zoomWindowSize, zoomFactor, progress) {
+        const zoomedRegionSize = geometry.region.size.multiply(zoomFactor);
+        const pannableRange = zoomedRegionSize.subtract(zoomWindowSize).clamp(0, Infinity);
+        // skip the part of the image which is cropped by the image element
+        const croppedOffset = geometry.source.offset.multiply(geometry.scale).multiply(zoomFactor);
+
+        return croppedOffset.add(pannableRange.multiply(progress));
     }
 
     /**
@@ -406,20 +556,20 @@ export default class MagnifierPlugin extends Plugin {
     }
 
     /**
-     * @param {Vector2} zoomImageSize
+     * sets and returns the lens size
      *
-     * @return {VectorBase|*}
+     * The lens marks exactly the image area which is rendered inside the zoom window,
+     * therefore it is derived from the zoom window and not from the image itself.
+     *
+     * @param {Vector2} regionSize
+     * @param {Vector2} zoomWindowSize
+     * @param {number} zoomFactor
+     *
+     * @return {Vector2}
      * @private
      */
-    _getOverlaySize(zoomImageSize) {
-        const overlaySize = zoomImageSize.divide(this.options.zoomFactor);
-
-        if (!this.options.keepAspectRatioOnZoom) {
-            const min = Math.min(overlaySize.x, overlaySize.y);
-
-            overlaySize.x = min;
-            overlaySize.y = min;
-        }
+    _getOverlaySize(regionSize, zoomWindowSize, zoomFactor) {
+        const overlaySize = zoomWindowSize.divide(zoomFactor).clamp(0, regionSize);
 
         this._overlay.style.width = `${Math.ceil(overlaySize.x)}px`;
         this._overlay.style.height = `${Math.ceil(overlaySize.y)}px`;

--- a/src/Storefront/Resources/app/storefront/test/plugin/magnifier/magnifier.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/magnifier/magnifier.plugin.test.js
@@ -1,4 +1,5 @@
 import MagnifierPlugin from 'src/plugin/magnifier/magnifier.plugin';
+import { Vector2 } from 'src/helper/vector.helper';
 
 /**
  * @package storefront
@@ -21,12 +22,12 @@ describe('MagnifierPlugin tests', () => {
         // Minimal PluginManager stub used by Plugin base class
         window.PluginManager = {
             getPluginInstancesFromElement: jest.fn(() => new Map()),
-            getPlugin: jest.fn(() => new Map([["instances", []]])),
+            getPlugin: jest.fn(() => new Map([['instances', []]])),
             initializePluginsInParentElement: jest.fn(),
         };
 
         // Ensure deterministic viewport height
-        Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true }); // maxHeight = 500
+        Object.defineProperty(window, 'innerHeight', { value: 2000, configurable: true }); // maxHeight = 1000
 
         element = document.querySelector('[data-magnifier]');
         magnifierPlugin = new MagnifierPlugin(element);
@@ -65,43 +66,296 @@ describe('MagnifierPlugin tests', () => {
         });
     });
 
+    describe('_getObjectFitScale', () => {
+        function imageWithFit(objectFit) {
+            const image = document.querySelector('.js-magnifier-image');
+            jest.spyOn(window, 'getComputedStyle').mockReturnValue({ objectFit });
+            return image;
+        }
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test('should scale uniformly by the smaller factor for object-fit: contain (storefront default)', () => {
+            const image = imageWithFit('contain');
+            // element 400x400, natural 800x1600 -> scaleX 0.5, scaleY 0.25 -> min 0.25
+            const scale = magnifierPlugin._getObjectFitScale(image, new Vector2(400, 400), new Vector2(800, 1600));
+
+            expect(scale.x).toBeCloseTo(0.25);
+            expect(scale.y).toBeCloseTo(0.25);
+        });
+
+        test('should scale uniformly by the larger factor for object-fit: cover', () => {
+            const image = imageWithFit('cover');
+            const scale = magnifierPlugin._getObjectFitScale(image, new Vector2(400, 400), new Vector2(800, 1600));
+
+            expect(scale.x).toBeCloseTo(0.5);
+            expect(scale.y).toBeCloseTo(0.5);
+        });
+
+        test('should scale per-axis for object-fit: fill', () => {
+            const image = imageWithFit('fill');
+            const scale = magnifierPlugin._getObjectFitScale(image, new Vector2(400, 400), new Vector2(800, 1600));
+
+            expect(scale.x).toBeCloseTo(0.5);
+            expect(scale.y).toBeCloseTo(0.25);
+        });
+
+        test('should not scale for object-fit: none', () => {
+            const image = imageWithFit('none');
+            const scale = magnifierPlugin._getObjectFitScale(image, new Vector2(400, 400), new Vector2(800, 1600));
+
+            expect(scale.x).toBe(1);
+            expect(scale.y).toBe(1);
+        });
+
+        test('should never scale up for object-fit: scale-down', () => {
+            const image = imageWithFit('scale-down');
+            // image smaller than element -> contain would scale up, scale-down must stay at 1
+            const scale = magnifierPlugin._getObjectFitScale(image, new Vector2(800, 800), new Vector2(400, 200));
+
+            expect(scale.x).toBe(1);
+            expect(scale.y).toBe(1);
+        });
+
+        test('should fall back to contain for an unknown/empty object-fit value (e.g. jsdom)', () => {
+            const image = imageWithFit('');
+            const scale = magnifierPlugin._getObjectFitScale(image, new Vector2(400, 400), new Vector2(800, 1600));
+
+            expect(scale.x).toBeCloseTo(0.25);
+            expect(scale.y).toBeCloseTo(0.25);
+        });
+    });
+
+    describe('_getZoomGeometry', () => {
+        function image({ natural, rect, objectFit = 'contain' }) {
+            const img = document.querySelector('.js-magnifier-image');
+            Object.defineProperty(img, 'naturalWidth', { value: natural.x, configurable: true });
+            Object.defineProperty(img, 'naturalHeight', { value: natural.y, configurable: true });
+            img.getBoundingClientRect = () => ({ width: rect.x, height: rect.y, top: 0, left: 0, right: 0, bottom: 0 });
+            jest.spyOn(window, 'getComputedStyle').mockReturnValue({ objectFit });
+            return img;
+        }
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test('should return null when the image has no layout yet', () => {
+            const img = image({ natural: { x: 0, y: 0 }, rect: { x: 0, y: 0 } });
+
+            expect(magnifierPlugin._getZoomGeometry(img)).toBeNull();
+        });
+
+        test('should letterbox a portrait image inside a square element (contain)', () => {
+            // natural 800x1600 (portrait), element 400x400 -> scale 0.25, rendered 200x400
+            const img = image({ natural: { x: 800, y: 1600 }, rect: { x: 400, y: 400 } });
+
+            const geometry = magnifierPlugin._getZoomGeometry(img);
+
+            expect(geometry.region.size.x).toBeCloseTo(200);
+            expect(geometry.region.size.y).toBeCloseTo(400);
+            // horizontally centered inside the 400px wide element
+            expect(geometry.region.offset.x).toBeCloseTo(100);
+            expect(geometry.region.offset.y).toBeCloseTo(0);
+            // whole image is visible -> no cropped source offset
+            expect(geometry.source.offset.x).toBeCloseTo(0);
+            expect(geometry.source.offset.y).toBeCloseTo(0);
+            expect(geometry.source.size.x).toBeCloseTo(800);
+            expect(geometry.source.size.y).toBeCloseTo(1600);
+        });
+
+        test('should crop a portrait image inside a square element (cover)', () => {
+            // natural 800x1600, element 400x400, cover -> scale 0.5, rendered 400x800, region clamped to 400x400
+            const img = image({ natural: { x: 800, y: 1600 }, rect: { x: 400, y: 400 }, objectFit: 'cover' });
+
+            const geometry = magnifierPlugin._getZoomGeometry(img);
+
+            expect(geometry.region.size.x).toBeCloseTo(400);
+            expect(geometry.region.size.y).toBeCloseTo(400);
+            expect(geometry.region.offset.x).toBeCloseTo(0);
+            expect(geometry.region.offset.y).toBeCloseTo(0);
+            // source is 800x800 centered vertically inside the 800x1600 image
+            expect(geometry.source.size.x).toBeCloseTo(800);
+            expect(geometry.source.size.y).toBeCloseTo(800);
+            expect(geometry.source.offset.x).toBeCloseTo(0);
+            expect(geometry.source.offset.y).toBeCloseTo(400);
+        });
+    });
+
+    describe('_getEffectiveZoomFactor', () => {
+        test('should keep the configured zoom factor when the zoomed image covers the window', () => {
+            magnifierPlugin.options.zoomFactor = 3;
+            // region 400x400 zoomed x3 = 1200x1200 >= window 500x300
+            const factor = magnifierPlugin._getEffectiveZoomFactor(new Vector2(400, 400), new Vector2(500, 300));
+
+            expect(factor).toBe(3);
+        });
+
+        test('should raise the zoom factor so the zoomed image never underflows the window', () => {
+            magnifierPlugin.options.zoomFactor = 2;
+            // region 100x400, window 500x300 -> needs factor 5 horizontally
+            const factor = magnifierPlugin._getEffectiveZoomFactor(new Vector2(100, 400), new Vector2(500, 300));
+
+            expect(factor).toBe(5);
+        });
+    });
+
+    describe('_getOverlaySize', () => {
+        beforeEach(() => {
+            magnifierPlugin._overlay = document.createElement('div');
+        });
+
+        test('should size the lens to the image area visible in the zoom window', () => {
+            // window 600x300, factor 3 -> lens 200x100
+            const size = magnifierPlugin._getOverlaySize(new Vector2(400, 400), new Vector2(600, 300), 3);
+
+            expect(size.x).toBeCloseTo(200);
+            expect(size.y).toBeCloseTo(100);
+            expect(magnifierPlugin._overlay.style.width).toBe('200px');
+            expect(magnifierPlugin._overlay.style.height).toBe('100px');
+        });
+
+        test('should never exceed the visible image region', () => {
+            // window 900x900, factor 3 -> raw lens 300x300, but region is only 200x400
+            const size = magnifierPlugin._getOverlaySize(new Vector2(200, 400), new Vector2(900, 900), 3);
+
+            expect(size.x).toBeCloseTo(200);
+            expect(size.y).toBeCloseTo(300);
+        });
+    });
+
+    describe('_getZoomProgress', () => {
+        test('should map the cursor position into a 0..1 range with the lens centered on the cursor', () => {
+            // region 400x400, lens 100x100 -> range 300x300; cursor at 200,200 -> lensPos 150,150 -> 0.5
+            const progress = magnifierPlugin._getZoomProgress(new Vector2(200, 200), new Vector2(400, 400), new Vector2(100, 100));
+
+            expect(progress.x).toBeCloseTo(0.5);
+            expect(progress.y).toBeCloseTo(0.5);
+        });
+
+        test('should clamp progress to the reachable range at the edges', () => {
+            const top = magnifierPlugin._getZoomProgress(new Vector2(0, 0), new Vector2(400, 400), new Vector2(100, 100));
+            expect(top.x).toBe(0);
+            expect(top.y).toBe(0);
+
+            const bottom = magnifierPlugin._getZoomProgress(new Vector2(400, 400), new Vector2(400, 400), new Vector2(100, 100));
+            expect(bottom.x).toBe(1);
+            expect(bottom.y).toBe(1);
+        });
+    });
+
+    describe('_getZoomBackgroundOffset', () => {
+        function geometryFor({ natural, scale, region, source }) {
+            return {
+                natural: new Vector2(natural.x, natural.y),
+                scale: new Vector2(scale.x, scale.y),
+                region: { offset: new Vector2(region.offset.x, region.offset.y), size: new Vector2(region.size.x, region.size.y) },
+                source: { offset: new Vector2(source.offset.x, source.offset.y), size: new Vector2(source.size.x, source.size.y) },
+            };
+        }
+
+        test('should keep the whole image height reachable for a portrait image in a landscape window (regression for issue 14498)', () => {
+            // portrait image, letterboxed contain: natural 800x1066, rendered region 323x430
+            const scale = 430 / 1066; // rendered region height 430 -> region width ~322.7
+            const geometry = geometryFor({
+                natural: { x: 800, y: 1066 },
+                scale: { x: scale, y: scale },
+                region: { offset: { x: 172, y: 0 }, size: { x: 800 * scale, y: 430 } },
+                source: { offset: { x: 0, y: 0 }, size: { x: 800, y: 1066 } },
+            });
+            const zoomWindow = new Vector2(543, 277); // landscape zoom window (ratio 1.96)
+            const zoomFactor = magnifierPlugin._getEffectiveZoomFactor(geometry.region.size, zoomWindow);
+            const backgroundSize = magnifierPlugin._getZoomBackgroundSize(geometry, zoomFactor);
+
+            const top = magnifierPlugin._getZoomBackgroundOffset(geometry, zoomWindow, zoomFactor, new Vector2(0.5, 0));
+            const bottom = magnifierPlugin._getZoomBackgroundOffset(geometry, zoomWindow, zoomFactor, new Vector2(0.5, 1));
+
+            // top of the image must be reachable...
+            expect(top.y).toBeCloseTo(0);
+            // ...and the bottom edge of the window must reach the bottom edge of the image
+            expect(bottom.y + zoomWindow.y).toBeCloseTo(backgroundSize.y);
+        });
+
+        test('should keep the whole image width reachable for a landscape image in a portrait window', () => {
+            // landscape image, letterboxed contain: natural 1600x800, rendered region 430x215
+            const scale = 430 / 1600;
+            const geometry = geometryFor({
+                natural: { x: 1600, y: 800 },
+                scale: { x: scale, y: scale },
+                region: { offset: { x: 0, y: 107 }, size: { x: 430, y: 800 * scale } },
+                source: { offset: { x: 0, y: 0 }, size: { x: 1600, y: 800 } },
+            });
+            const zoomWindow = new Vector2(277, 543); // portrait zoom window (ratio 0.51)
+            const zoomFactor = magnifierPlugin._getEffectiveZoomFactor(geometry.region.size, zoomWindow);
+            const backgroundSize = magnifierPlugin._getZoomBackgroundSize(geometry, zoomFactor);
+
+            const left = magnifierPlugin._getZoomBackgroundOffset(geometry, zoomWindow, zoomFactor, new Vector2(0, 0.5));
+            const right = magnifierPlugin._getZoomBackgroundOffset(geometry, zoomWindow, zoomFactor, new Vector2(1, 0.5));
+
+            expect(left.x).toBeCloseTo(0);
+            expect(right.x + zoomWindow.x).toBeCloseTo(backgroundSize.x);
+        });
+
+        test('should skip the cropped part of the image for object-fit: cover', () => {
+            // cover: source is vertically centered, 400px cropped at the top in source coords
+            const geometry = geometryFor({
+                natural: { x: 800, y: 1600 },
+                scale: { x: 0.5, y: 0.5 },
+                region: { offset: { x: 0, y: 0 }, size: { x: 400, y: 400 } },
+                source: { offset: { x: 0, y: 400 }, size: { x: 800, y: 800 } },
+            });
+            const zoomWindow = new Vector2(400, 400);
+            const zoomFactor = 3;
+
+            const top = magnifierPlugin._getZoomBackgroundOffset(geometry, zoomWindow, zoomFactor, new Vector2(0, 0));
+
+            // the first visible row skips the cropped 400px (in source) * scale 0.5 * factor 3 = 600px
+            expect(top.y).toBeCloseTo(600);
+        });
+    });
+
     describe('_setZoomImageSize', () => {
         test('should clamp height to window.innerHeight / 2 when computed height exceeds maxHeight', () => {
-            // keepAspectRatioOnZoom: true (default), scaleZoomImage: false (default)
-            // zoomImageSize.y (desired) = 800 > maxHeight (500) -> expect 500
+            Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true }); // maxHeight = 500
             magnifierPlugin._zoomImage.getBoundingClientRect = () => ({ width: 400, height: 800, top: 0, left: 0, right: 0, bottom: 0 });
 
-            // imageSize doesn't affect this branch, but provide sensible values
-            const imageSize = { x: 400, y: 800 };
-
-            magnifierPlugin._setZoomImageSize(imageSize);
+            magnifierPlugin._setZoomImageSize(new Vector2(400, 800));
 
             expect(magnifierPlugin._zoomImage.style.height).toBe('500px');
             expect(magnifierPlugin._zoomImage.style.minHeight).toBe('500px');
         });
 
         test('should not clamp when computed height is smaller than maxHeight', () => {
-            // keepAspectRatioOnZoom: true (default), scaleZoomImage: false (default)
-            // zoomImageSize.y (desired) = 300 < maxHeight (500) -> expect 300
+            Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true }); // maxHeight = 500
             magnifierPlugin._zoomImage.getBoundingClientRect = () => ({ width: 400, height: 300, top: 0, left: 0, right: 0, bottom: 0 });
 
-            const imageSize = { x: 400, y: 800 };
-
-            magnifierPlugin._setZoomImageSize(imageSize);
+            magnifierPlugin._setZoomImageSize(new Vector2(400, 800));
 
             expect(magnifierPlugin._zoomImage.style.height).toBe('300px');
             expect(magnifierPlugin._zoomImage.style.minHeight).toBe('300px');
         });
 
-        test('should clamp when scaleZoomImage is true and computed height exceeds maxHeight', () => {
-            // Activate scaleZoomImage path
+        test('should derive the height from the region ratio when scaleZoomImage is enabled', () => {
+            Object.defineProperty(window, 'innerHeight', { value: 4000, configurable: true }); // maxHeight = 2000 (no clamp)
             magnifierPlugin.options.scaleZoomImage = true;
-
-            // zoomImageSize.x * factor -> 400 * (800/400) = 800 > 500 -> expect 500
+            // width 400, region ratio y/x = 800/400 = 2 -> height = 400 * 2 = 800
             magnifierPlugin._zoomImage.getBoundingClientRect = () => ({ width: 400, height: 100, top: 0, left: 0, right: 0, bottom: 0 });
-            const imageSize = { x: 400, y: 800 }; // factor = 2
 
-            magnifierPlugin._setZoomImageSize(imageSize);
+            magnifierPlugin._setZoomImageSize(new Vector2(400, 800));
+
+            expect(magnifierPlugin._zoomImage.style.height).toBe('800px');
+            expect(magnifierPlugin._zoomImage.style.minHeight).toBe('800px');
+        });
+
+        test('should clamp the scaleZoomImage height to maxHeight as well', () => {
+            Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true }); // maxHeight = 500
+            magnifierPlugin.options.scaleZoomImage = true;
+            // width 400 * ratio 2 = 800 -> clamped to 500
+            magnifierPlugin._zoomImage.getBoundingClientRect = () => ({ width: 400, height: 100, top: 0, left: 0, right: 0, bottom: 0 });
+
+            magnifierPlugin._setZoomImageSize(new Vector2(400, 800));
 
             expect(magnifierPlugin._zoomImage.style.height).toBe('500px');
             expect(magnifierPlugin._zoomImage.style.minHeight).toBe('500px');
@@ -132,6 +386,7 @@ describe('MagnifierPlugin tests', () => {
             Object.defineProperty(image, 'naturalHeight', { value: 800, configurable: true });
             image.getBoundingClientRect = () => ({ width: 400, height: 300, top: 20, left: 10, right: 0, bottom: 0 });
             imageContainer.getBoundingClientRect = () => ({ top: 20, left: 10, width: 400, height: 300, right: 0, bottom: 0 });
+            jest.spyOn(window, 'getComputedStyle').mockReturnValue({ objectFit: 'contain' });
 
             jest.spyOn(magnifierPlugin, '_isActive').mockReturnValue(true);
             const setOverlayPositionSpy = jest.spyOn(magnifierPlugin, '_setOverlayPosition');
@@ -149,6 +404,54 @@ describe('MagnifierPlugin tests', () => {
             expect(magnifierPlugin._zoomImage).toBeInstanceOf(HTMLElement);
             expect(setOverlayPositionSpy).toHaveBeenCalled();
             expect(setZoomImageSpy).toHaveBeenCalled();
+        });
+
+        test('should map the bottom of a portrait image in a landscape window to the bottom of the zoom (regression for issue 14498)', () => {
+            const imageContainer = document.querySelector('.js-magnifier-container');
+            const image = document.querySelector('.js-magnifier-image');
+
+            // portrait image 800x1066 rendered contain into a 323x430 element at the top-left
+            image.setAttribute('data-full-image', '/full/image.jpg');
+            Object.defineProperty(image, 'naturalWidth', { value: 800, configurable: true });
+            Object.defineProperty(image, 'naturalHeight', { value: 1066, configurable: true });
+            image.getBoundingClientRect = () => ({ width: 323, height: 430, top: 0, left: 0, right: 0, bottom: 0 });
+            imageContainer.getBoundingClientRect = () => ({ top: 0, left: 0, width: 323, height: 430, right: 0, bottom: 0 });
+            jest.spyOn(window, 'getComputedStyle').mockReturnValue({ objectFit: 'contain' });
+            // landscape zoom window 543x277 (pinned; _createZoomImage replaces the element during the flow)
+            jest.spyOn(magnifierPlugin, '_getZoomImageSize').mockReturnValue(new Vector2(543, 277));
+            jest.spyOn(magnifierPlugin, '_isActive').mockReturnValue(true);
+
+            // hover the very bottom center of the image
+            magnifierPlugin._onMouseMove({ pageX: 161, pageY: 430 }, imageContainer, image);
+
+            const parse = (value) => value.split(' ').map((part) => parseFloat(part));
+            const [, bgHeight] = parse(magnifierPlugin._zoomImage.style.backgroundSize);
+            const [, bgPosY] = parse(magnifierPlugin._zoomImage.style.backgroundPosition);
+            const windowHeight = 277;
+
+            // region height 430 * zoomFactor 3 = background height 1290
+            expect(bgHeight).toBeCloseTo(1290);
+            // bottom edge of the window must align with the bottom edge of the image
+            expect(-bgPosY + windowHeight).toBeCloseTo(bgHeight);
+        });
+
+        test('should not throw when the image has no layout yet', () => {
+            const imageContainer = document.querySelector('.js-magnifier-container');
+            const image = document.querySelector('.js-magnifier-image');
+
+            image.setAttribute('data-full-image', '/full/image.jpg');
+            Object.defineProperty(image, 'naturalWidth', { value: 0, configurable: true });
+            Object.defineProperty(image, 'naturalHeight', { value: 0, configurable: true });
+            image.getBoundingClientRect = () => ({ width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 });
+            jest.spyOn(window, 'getComputedStyle').mockReturnValue({ objectFit: 'contain' });
+            jest.spyOn(magnifierPlugin, '_isActive').mockReturnValue(true);
+            const setZoomImageSpy = jest.spyOn(magnifierPlugin, '_setZoomImage');
+
+            expect(() => {
+                magnifierPlugin._onMouseMove({ pageX: 10, pageY: 10 }, imageContainer, image);
+            }).not.toThrow();
+
+            expect(setZoomImageSpy).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

The product detail magnifier assumed the zoom window and the gallery image share the same aspect ratio. When they differ (e.g. a portrait image in a landscape zoom window), the upper or lower part of the image was unreachable even though the lens indicated it.

### 2. What does this change do, exactly?

Derives the lens-to-zoom mapping from the actual zoom window size and the image's visible region (honouring `object-fit`) instead of the image aspect ratio, so every part of the image stays reachable for any image and zoom window aspect ratio.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a product detail page with a gallery image whose aspect ratio differs from the zoom window (e.g. a portrait image).
2. Hover the image to activate the magnifier and move to the bottom edge.
3. Before: the bottom of the image is never shown. After: the whole image is reachable.

### 4. Please link to the relevant issues (if any).

- closes #14498

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
