### PR TITLE
chore: Prepare framework for PHPStan update 2026-08

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -830,12 +830,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/src/Core/Framework/Struct/Serializer/StructNormalizer.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',
-    'identifier' => 'shopware.domainException',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Core/Framework/Struct/Struct.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Method Shopware\\Core\\Framework\\Validation\\DataValidator::getViolations() has parameter $data with no value type specified in iterable type array.',
     'identifier' => 'missingType.iterableValue',
     'count' => 1,

--- a/src/Core/Framework/Adapter/Database/MySQLFactory.php
+++ b/src/Core/Framework/Adapter/Database/MySQLFactory.php
@@ -56,7 +56,7 @@ class MySQLFactory
         $parameters['driverOptions'] = [
             \PDO::ATTR_STRINGIFY_FETCHES => true,
             \PDO::ATTR_TIMEOUT => 5,
-        ] + $dsnParameters['driverOptions'];
+        ] + ($dsnParameters['driverOptions'] ?? []);
 
         $initCommands = [
             'SET @@session.time_zone = \'+00:00\'',
@@ -100,12 +100,14 @@ class MySQLFactory
             $parameters['primary'] = array_merge([
                 'charset' => $parameters['charset'],
             ], $dsnParameters);
-            $parameters['primary']['driverOptions'] = $parameters['driverOptions'] + $dsnParameters['driverOptions'];
+            unset($parameters['primary']['primary'], $parameters['primary']['replica'], $parameters['primary']['keepReplica']);
+            $parameters['primary']['driverOptions'] = $parameters['driverOptions'] + ($dsnParameters['driverOptions'] ?? []);
 
             $parameters['replica'] = [];
 
             for ($i = 0; $replicaUrl = (string) EnvironmentHelper::getVariable('DATABASE_REPLICA_' . $i . '_URL'); ++$i) {
                 $replicaParams = self::parseDsn($dsnParser, $replicaUrl);
+                unset($replicaParams['primary'], $replicaParams['replica'], $replicaParams['keepReplica']);
 
                 $parameters['replica'][$i] = array_merge([
                     'charset' => $parameters['charset'],
@@ -118,7 +120,7 @@ class MySQLFactory
     }
 
     /**
-     * @return Params&array{driverOptions: array<mixed>}
+     * @return Params
      */
     private static function parseDsn(DsnParser $dsnParser, string $url): array
     {

--- a/src/Core/Framework/Adapter/Redis/RedisConnectionsCompilerPass.php
+++ b/src/Core/Framework/Adapter/Redis/RedisConnectionsCompilerPass.php
@@ -13,8 +13,6 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @internal
- *
- * @phpstan-type ConnectionConfiguration array{dsn: string}
  */
 #[Package('framework')]
 class RedisConnectionsCompilerPass implements CompilerPassInterface
@@ -36,19 +34,21 @@ class RedisConnectionsCompilerPass implements CompilerPassInterface
             return [];
         }
 
-        /** @var ConnectionConfiguration[] $connections */
         $connections = $container->getParameter('shopware.redis.connections');
+        if (!\is_array($connections)) {
+            return [];
+        }
 
         $connectionServices = [];
         foreach ($connections as $name => $connection) {
-            $dsn = $connection['dsn'] ?? null;
+            $dsn = \is_array($connection) ? ($connection['dsn'] ?? null) : null;
 
             if (!\is_string($dsn)) {
                 throw AdapterException::invalidRedisConnectionDsn($name);
             }
 
             $serviceId = 'shopware.redis.connection.' . $name;
-            $definition = $this->createRedisDefinition($connection);
+            $definition = $this->createRedisDefinition($dsn);
             $container->setDefinition($serviceId, $definition);
             $connectionServices[$serviceId] = new Reference($serviceId);
         }
@@ -56,18 +56,13 @@ class RedisConnectionsCompilerPass implements CompilerPassInterface
         return $connectionServices;
     }
 
-    /**
-     * @param ConnectionConfiguration $connection
-     */
-    private function createRedisDefinition(array $connection): Definition
+    private function createRedisDefinition(string $dsn): Definition
     {
         $definition = new Definition('Redis');
         $definition
             ->setFactory([new Reference(RedisConnectionFactory::class), 'create'])
             ->setPublic(false)
-            ->setArguments([
-                $connection['dsn'],
-            ]);
+            ->setArguments([$dsn]);
 
         // Under the hood, redis connections are created by \Symfony\Component\Cache\Adapter\RedisAdapter::createConnection, which may return
         // different types depending on the redis extension used and dsn provided.

--- a/src/Core/Framework/Adapter/Twig/SecurityExtension.php
+++ b/src/Core/Framework/Adapter/Twig/SecurityExtension.php
@@ -85,11 +85,14 @@ class SecurityExtension extends AbstractExtension
             throw AdapterException::securityFunctionNotAllowed($function);
         }
 
+        if (!\is_callable($function)) {
+            return null;
+        }
+
         if (!\is_array($array)) {
             $array = iterator_to_array($array);
         }
 
-        // @phpstan-ignore-next-line
         return array_reduce($array, $function, $initial);
     }
 
@@ -113,12 +116,14 @@ class SecurityExtension extends AbstractExtension
             throw AdapterException::securityFunctionNotAllowed($arrow);
         }
 
+        if (!\is_callable($arrow)) {
+            return null;
+        }
+
         if (\is_array($array)) {
-            // @phpstan-ignore-next-line
             return array_filter($array, $arrow, \ARRAY_FILTER_USE_BOTH);
         }
 
-        // @phpstan-ignore-next-line
         return new \CallbackFilterIterator(new \IteratorIterator($array), $arrow);
     }
 
@@ -146,8 +151,7 @@ class SecurityExtension extends AbstractExtension
             $array = iterator_to_array($array);
         }
 
-        if ($arrow !== null) {
-            // @phpstan-ignore-next-line
+        if (\is_callable($arrow)) {
             uasort($array, $arrow);
         } else {
             asort($array);

--- a/src/Core/Framework/FrameworkException.php
+++ b/src/Core/Framework/FrameworkException.php
@@ -29,6 +29,7 @@ class FrameworkException extends HttpException
     private const MISSING_OPTIONS = 'FRAMEWORK__MISSING_OPTIONS';
     private const INVALID_OPTIONS = 'FRAMEWORK__INVALID_OPTIONS';
     private const ASSOCIATION_NOT_FOUND = 'FRAMEWORK__ASSOCIATION_NOT_FOUND';
+    private const CREATE_FROM_ERROR = 'FRAMEWORK__CREATE_FROM_ERROR';
 
     public static function projectDirNotExists(string $dir, ?\Throwable $e = null): self
     {
@@ -150,5 +151,19 @@ class FrameworkException extends HttpException
     public static function unexpectedType(mixed $givenType, string $expectedType): UnexpectedTypeException
     {
         return new UnexpectedTypeException($givenType, $expectedType);
+    }
+
+    #[ReturnTypeNarrowing(version: 'v6.8.0', newType: 'self')]
+    public static function createFromError(string $message): self|\InvalidArgumentException
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return new \InvalidArgumentException($message);
+        }
+
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::CREATE_FROM_ERROR,
+            $message
+        );
     }
 }

--- a/src/Core/Framework/Increment/IncrementerGatewayCompilerPass.php
+++ b/src/Core/Framework/Increment/IncrementerGatewayCompilerPass.php
@@ -21,7 +21,7 @@ class IncrementerGatewayCompilerPass implements CompilerPassInterface
         $tag = 'shopware.increment.gateway';
 
         foreach ($services as $pool => $service) {
-            $type = $service['type'] ?? null;
+            $type = $service['type'];
 
             if (!\is_string($type)) {
                 throw IncrementException::wrongGatewayType($pool);

--- a/src/Core/Framework/Mcp/Command/DebugMcpCommand.php
+++ b/src/Core/Framework/Mcp/Command/DebugMcpCommand.php
@@ -223,7 +223,7 @@ class DebugMcpCommand extends Command
             foreach ($registry->getResources()->references as $resource) {
                 \assert($resource instanceof ResourceDefinition);
 
-                if (($resource->name ?? $resource->uri) === $name || $resource->uri === $name) {
+                if ($resource->name === $name || $resource->uri === $name) {
                     $ref = $registry->getResource($resource->uri, false);
                     $this->renderResourceDetail($io, $resource, $ref->handler, $scope['label']);
 
@@ -245,7 +245,7 @@ class DebugMcpCommand extends Command
     {
         $rows = [];
         $properties = $tool->inputSchema['properties'] ?? [];
-        $required = \is_array($tool->inputSchema['required'] ?? null) ? $tool->inputSchema['required'] : [];
+        $required = \is_array($tool->inputSchema['required']) ? $tool->inputSchema['required'] : [];
 
         if (\is_array($properties)) {
             foreach ($properties as $paramName => $def) {
@@ -325,7 +325,7 @@ class DebugMcpCommand extends Command
             $meta[] = ['MIME type' => $resource->mimeType];
         }
 
-        $this->renderCapabilityDetail($io, $resource->name ?? $resource->uri, $meta, $resource->description);
+        $this->renderCapabilityDetail($io, $resource->name, $meta, $resource->description);
     }
 
     /**
@@ -453,7 +453,7 @@ class DebugMcpCommand extends Command
             \assert($resource instanceof ResourceDefinition);
 
             $ref = $registry->getResource($resource->uri, false);
-            $rows[] = [$resource->name ?? $resource->uri, $this->describeHandler($ref->handler)];
+            $rows[] = [$resource->name, $this->describeHandler($ref->handler)];
         }
 
         $this->renderTable($io, $rows);

--- a/src/Core/Framework/Mcp/McpJsonRpcResponse.php
+++ b/src/Core/Framework/Mcp/McpJsonRpcResponse.php
@@ -178,7 +178,7 @@ class McpJsonRpcResponse implements \JsonSerializable
             }
             if (\array_key_exists('capabilities', $resultData)) {
                 $protocolVersion = $resultData['protocolVersion'] ?? null;
-                $capabilitiesData = $resultData['capabilities'] ?? null;
+                $capabilitiesData = $resultData['capabilities'];
                 $serverInfoData = $resultData['serverInfo'] ?? null;
 
                 if (!\is_string($protocolVersion) || !\is_array($capabilitiesData) || !\is_array($serverInfoData)) {

--- a/src/Core/Framework/Struct/CreateFromTrait.php
+++ b/src/Core/Framework/Struct/CreateFromTrait.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Struct;
 
+use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('framework')]
@@ -13,7 +14,7 @@ trait CreateFromTrait
             $self = (new \ReflectionClass(static::class))
                 ->newInstanceWithoutConstructor();
         } catch (\ReflectionException $exception) {
-            throw new \InvalidArgumentException($exception->getMessage());
+            throw FrameworkException::createFromError($exception->getMessage());
         }
 
         foreach (get_object_vars($object) as $property => $value) {

--- a/tests/unit/Core/Framework/Adapter/Redis/RedisConnectionsCompilerPassTest.php
+++ b/tests/unit/Core/Framework/Adapter/Redis/RedisConnectionsCompilerPassTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Framework\Adapter\Redis;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Cache\RedisConnectionFactory;
 use Shopware\Core\Framework\Adapter\Redis\RedisConnectionProvider;
 use Shopware\Core\Framework\Adapter\Redis\RedisConnectionsCompilerPass;
@@ -81,5 +82,23 @@ class RedisConnectionsCompilerPassTest extends TestCase
         $interfaces = class_implements($className);
         static::assertIsArray($interfaces);
         static::assertArrayHasKey(ContainerInterface::class, $interfaces);
+    }
+
+    public function testPrepareConnectionsIgnoresNonArrayConnections(): void
+    {
+        $this->containerBuilder->setParameter('shopware.redis.connections', 'invalid');
+
+        static::assertSame([], (new RedisConnectionsCompilerPass())->prepareConnections($this->containerBuilder));
+    }
+
+    public function testPrepareConnectionsThrowsForNonStringDsn(): void
+    {
+        $this->containerBuilder->setParameter('shopware.redis.connections', [
+            'db' => ['dsn' => 123],
+        ]);
+
+        $this->expectExceptionObject(AdapterException::invalidRedisConnectionDsn('db'));
+
+        (new RedisConnectionsCompilerPass())->prepareConnections($this->containerBuilder);
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Twig/SecurityExtensionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/SecurityExtensionTest.php
@@ -100,6 +100,14 @@ class SecurityExtensionTest extends TestCase
         static::assertSame('3', $this->runTwig('{{ test|reduce((a, b) => a + b)|json_encode|raw }}', [], ['test' => new \ArrayIterator([1, 2])]));
     }
 
+    public function testReduceWithNotCallableFunction(): void
+    {
+        static::assertSame(
+            '',
+            $this->runTwig('{{ ["value"]|reduce(functionName)|join }}', ['not_callable'], ['functionName' => 'not_callable'])
+        );
+    }
+
     public function testFilterClosure(): void
     {
         static::assertSame('a', $this->runTwig('{{ ["a", "b", "c"]|filter(v => v == "a")|join }}'));
@@ -110,6 +118,14 @@ class SecurityExtensionTest extends TestCase
         static::assertSame(
             'a',
             $this->runTwig('{{ test|filter(v => v == "a")|join }}', [], ['test' => new \ArrayIterator(['a', 'b', 'c'])])
+        );
+    }
+
+    public function testFilterWithNotCallableFunction(): void
+    {
+        static::assertSame(
+            '',
+            $this->runTwig('{{ ["value"]|filter(functionName)|join }}', ['not_callable'], ['functionName' => 'not_callable'])
         );
     }
 

--- a/tests/unit/Core/Framework/FrameworkExceptionTest.php
+++ b/tests/unit/Core/Framework/FrameworkExceptionTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
@@ -16,15 +18,43 @@ class FrameworkExceptionTest extends TestCase
 {
     public function testProjectDirNotExists(): void
     {
-        $this->expectExceptionObject(FrameworkException::projectDirNotExists('test'));
+        $exception = FrameworkException::projectDirNotExists('test');
 
-        throw FrameworkException::projectDirNotExists('test');
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__PROJECT_DIR_NOT_EXISTS', $exception->getErrorCode());
+        static::assertSame('Project directory "test" does not exist.', $exception->getMessage());
+        static::assertSame(['dir' => 'test'], $exception->getParameters());
     }
 
     public function testCollectionElementInvalidType(): void
     {
-        $this->expectExceptionObject(FrameworkException::collectionElementInvalidType('foo', 'bar'));
+        $exception = FrameworkException::collectionElementInvalidType('foo', 'bar');
 
-        throw FrameworkException::collectionElementInvalidType('foo', 'bar');
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__INVALID_COLLECTION_ELEMENT_TYPE', $exception->getErrorCode());
+        static::assertSame('Expected collection element of type foo got bar', $exception->getMessage());
+        static::assertSame(['expected' => 'foo', 'element' => 'bar'], $exception->getParameters());
+    }
+
+    public function testCreateFromError(): void
+    {
+        $exception = FrameworkException::createFromError('error message');
+
+        static::assertInstanceOf(FrameworkException::class, $exception);
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('FRAMEWORK__CREATE_FROM_ERROR', $exception->getErrorCode());
+        static::assertSame('error message', $exception->getMessage());
+        static::assertSame([], $exception->getParameters());
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement
+     */
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testCreateFromErrorWithDeprecatedBehavior(): void
+    {
+        $exception = FrameworkException::createFromError('error message');
+
+        static::assertEquals(new \InvalidArgumentException('error message'), $exception);
     }
 }

--- a/tests/unit/Core/Framework/Store/Exception/StoreApiExceptionTest.php
+++ b/tests/unit/Core/Framework/Store/Exception/StoreApiExceptionTest.php
@@ -90,7 +90,7 @@ class StoreApiExceptionTest extends TestCase
         );
 
         foreach ((new StoreApiException($clientException))->getErrors() as $error) {
-            static::assertSame('title', $error['title'] ?? null);
+            static::assertSame('title', $error['title']);
         }
     }
 
@@ -107,7 +107,7 @@ class StoreApiExceptionTest extends TestCase
         );
 
         foreach ((new StoreApiException($clientException))->getErrors() as $error) {
-            static::assertSame('https://shopware.docs', $error['meta']['documentationLink'] ?? null);
+            static::assertSame('https://shopware.docs', $error['meta']['documentationLink']);
         }
     }
 
@@ -132,9 +132,9 @@ class StoreApiExceptionTest extends TestCase
         foreach ($exception->getErrors(true) as $error) {
             static::assertSame('FRAMEWORK__STORE_ERROR', $error['code']);
             static::assertSame((string) Response::HTTP_INTERNAL_SERVER_ERROR, $error['status']);
-            static::assertSame('title', $error['title'] ?? null);
+            static::assertSame('title', $error['title']);
             static::assertSame('description', $error['detail']);
-            static::assertSame('https://shopware.docs', $error['meta']['documentationLink'] ?? null);
+            static::assertSame('https://shopware.docs', $error['meta']['documentationLink']);
             static::assertIsString($error['trace'] ?? null);
         }
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Preparation for https://github.com/shopware/shopware/pull/17661

### 2. What does this change do, exactly?

Prepare framework code for PHPStan update

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
