### PR TITLE
chore: fix incorrect translation in copyrightInfo

### DIFF
--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -773,7 +773,7 @@
     "includeVatTextPage": "All prices incl. VAT plus <a href=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
     "excludeVatText": "%star%All prices excl. VAT plus <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
     "excludeVatTextPage": "All prices excl. VAT plus <a href=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
-    "copyrightInfo": "Realised with Shopware"
+    "copyrightInfo": "Built with Shopware"
   },
   "captcha": {
     "googleReCaptcha": {


### PR DESCRIPTION
### 1. Why is this change necessary?

Fix incorrect translation:

"Realised with Shopware" is a false friend translation from German. The German "realisiert" in this context means "built/created/made", not the English "realised" (which means to become aware of something).

### 2. What does this change do, exactly?

Change to "Built with Shopware"

### 3. Describe each step to reproduce the issue or behaviour.

Check the english footer