### PR TITLE
ci: run Storefront Lighthouse only in public repository

### DIFF
--- a/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
+++ b/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
@@ -1,5 +1,10 @@
 import { test } from '@fixtures/AcceptanceTest';
 
+test.skip(
+    process.env.GITHUB_REPOSITORY === 'shopware/shopware-private',
+    'Lighthouse tests require the performance characteristics of the public repository runners.',
+);
+
 /**
  * These tests should only run against APP_ENV=Prod
  */


### PR DESCRIPTION
### 1. Why is this change necessary?

Private repositories use lower-capacity GitHub-hosted runners than the public repository. The Storefront Lighthouse performance threshold can therefore fail without a Storefront regression.

### 2. What does this change do, exactly?

Skips the Storefront Lighthouse specs only in `shopware/shopware-private`. Local runs and public-repository CI remain unchanged.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a pull request in `shopware/shopware-private`.
2. Observe an acceptance shard fail because the Lighthouse performance score is below its threshold.

### 4. Please link to the relevant issues (if any).

- Relates to https://github.com/shopware/shopware/pull/19041

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
